### PR TITLE
refactor: remove `tempfile` fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2159,14 +2159,15 @@ checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
 
 [[package]]
 name = "tempfile"
-version = "3.20.0"
-source = "git+https://github.com/crepererum/tempfile.git?rev=bdfa162a052d5239c4d42e6b706f9d2e9e040f02#bdfa162a052d5239c4d42e6b706f9d2e9e040f02"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
 dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.8",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,6 @@ datafusion-expr = { git = "https://github.com/influxdata/arrow-datafusion.git", 
 # patches to get wasi p2 to run without extra feature flags
 # See <https://github.com/rust-lang/rust/issues/130323>.
 pyo3 = { git = "https://github.com/crepererum/pyo3.git", rev = "92f97bdb0291852e2e0fc59312b69e9f73e47f16" }
-tempfile = { git = "https://github.com/crepererum/tempfile.git", rev = "bdfa162a052d5239c4d42e6b706f9d2e9e040f02" }
 
 # faster tests
 [profile.dev.package]


### PR DESCRIPTION
In an early version of the code, the Rust guest depended on the whole `datafusion` crate and -- indirectly -- on `tempfile`. Since then we've trimmed the dependencies and the guest only depends on the datafusion subcrates that it actually needs. And so `tempfile` is no longer compiled for WASIp2.
