### PR TITLE
refactor: extend `scalar-udfs` WIT interface

### DIFF
--- a/guests/python/src/lib.rs
+++ b/guests/python/src/lib.rs
@@ -77,10 +77,10 @@ fn root() -> Option<Vec<u8>> {
     Some(ROOT_TAR.to_vec())
 }
 
-fn udfs() -> Vec<Arc<dyn ScalarUDFImpl>> {
+fn udfs(_source: String) -> DataFusionResult<Vec<Arc<dyn ScalarUDFImpl>>> {
     pyo3::prepare_freethreaded_python();
 
-    vec![Arc::new(Test::new())]
+    Ok(vec![Arc::new(Test::new())])
 }
 
 export! {

--- a/guests/rust/examples/add_one.rs
+++ b/guests/rust/examples/add_one.rs
@@ -90,8 +90,8 @@ fn root() -> Option<Vec<u8>> {
     None
 }
 
-fn udfs() -> Vec<Arc<dyn ScalarUDFImpl>> {
-    vec![Arc::new(AddOne::new())]
+fn udfs(_source: String) -> DataFusionResult<Vec<Arc<dyn ScalarUDFImpl>>> {
+    Ok(vec![Arc::new(AddOne::new())])
 }
 
 export! {

--- a/guests/rust/src/lib.rs
+++ b/guests/rust/src/lib.rs
@@ -19,13 +19,21 @@ macro_rules! export {
                 $root_fs_tar()
             }
 
-            fn scalar_udfs() -> Vec<$crate::bindings::exports::datafusion_udf_wasm::udf::types::ScalarUdf> {
-                $scalar_udfs()
-                    .into_iter()
+            fn scalar_udfs(
+                source: String,
+            ) -> Result<
+                Vec<$crate::bindings::exports::datafusion_udf_wasm::udf::types::ScalarUdf>,
+                $crate::bindings::exports::datafusion_udf_wasm::udf::types::DataFusionError,
+            > {
+                let udfs = $scalar_udfs(source)?;
+
+                Ok(
+                    udfs.into_iter()
                     .map(|udf| $crate::bindings::exports::datafusion_udf_wasm::udf::types::ScalarUdf::new(
                         $crate::wrapper::ScalarUdfWrapper::new(udf)
                     ))
                     .collect()
+                )
             }
         }
 

--- a/host/src/error.rs
+++ b/host/src/error.rs
@@ -29,3 +29,20 @@ impl<T> WasmToDataFusionResultExt for Result<T, wasmtime::Error> {
         self.map_err(|err| WasmToDataFusionErrorExt::context(err, msg, stderr))
     }
 }
+
+pub(crate) trait DataFusionResultExt {
+    type T;
+
+    fn context(self, description: impl Into<String>) -> Result<Self::T, DataFusionError>;
+}
+
+impl<T, E> DataFusionResultExt for Result<T, E>
+where
+    E: Into<DataFusionError>,
+{
+    type T = T;
+
+    fn context(self, description: impl Into<String>) -> Result<Self::T, DataFusionError> {
+        self.map_err(|e| e.into().context(description))
+    }
+}

--- a/host/tests/integration_tests/python.rs
+++ b/host/tests/integration_tests/python.rs
@@ -14,7 +14,7 @@ async fn test() {
     .await
     .unwrap();
 
-    let mut udfs = WasmScalarUdf::new(&data).await.unwrap();
+    let mut udfs = WasmScalarUdf::new(&data, "".to_owned()).await.unwrap();
     assert_eq!(udfs.len(), 1);
     let udf = udfs.pop().unwrap();
 

--- a/host/tests/integration_tests/rust.rs
+++ b/host/tests/integration_tests/rust.rs
@@ -17,7 +17,7 @@ async fn test_add_one() {
     .await
     .unwrap();
 
-    let mut udfs = WasmScalarUdf::new(&data).await.unwrap();
+    let mut udfs = WasmScalarUdf::new(&data, "".to_owned()).await.unwrap();
     assert_eq!(udfs.len(), 1);
     let udf = udfs.pop().unwrap();
 

--- a/wit/world.wit
+++ b/wit/world.wit
@@ -87,7 +87,7 @@ interface types {
     }
 
     root-fs-tar: func() -> option<list<u8>>;
-    scalar-udfs: func() -> list<scalar-udf>;
+    scalar-udfs: func(source: string) -> result<list<scalar-udf>, data-fusion-error>;
 }
 
 world datafusion {


### PR DESCRIPTION
- make it fallible
- pass some opaque string into the guest

Both are required to properly pass Python source code from the host into the guest.

Split from #49, where this interface will actually be used.
