### PR TITLE
feat: support `Optional[T]` in Python

### DIFF
--- a/guests/python/src/signature.rs
+++ b/guests/python/src/signature.rs
@@ -39,6 +39,9 @@ pub(crate) enum PythonType {
 /// - <https://docs.python.org/3/library/stdtypes.html#the-null-object>
 ///
 /// Nullable types are represented using a union with another type, e.g. `int | None`.
+///
+/// There used to be an older representation too: `typing.Optional[int]`. As of Python 3.14, this results in the same
+/// representation as `int | None`. See <https://docs.python.org/3.14/whatsnew/3.14.html#typing>. So we support both.
 #[derive(Debug)]
 pub(crate) struct PythonNullableType {
     /// Python type.


### PR DESCRIPTION
I actually wanted to implement this but it turns out that Python 3.14 does this automatically for us (this doesn't "just work" in Python 3.13). Since we're using the release candidate for the not-yet-released 3.14, that's fine. I however decided to add a guard/check so nobody tries to run our WASM payload with an older version (or a too-new one).
