### PR TITLE
chore: use Python 3.14.0 final

### DIFF
--- a/guests/python/Justfile
+++ b/guests/python/Justfile
@@ -1,12 +1,12 @@
 PYTHON_VERSION_MAJOR := "3"
 PYTHON_VERSION_MINOR := "14"
-PYTHON_VERSION_MICRO := "0rc2"
+PYTHON_VERSION_MICRO := "0"
 
 WASI_SDK_VERSION_MAJOR := "24"
 WASI_SDK_VERSION_MINOR := "0"
 
-SHA256_PYTHON_SDK := "be233d6baf6a770550634fd6f51e12f15c1837455105c7e8b2a45efd3926805d"
-SHA256_PYTHON_SDK_BUILD := "d5240fdf3e2aedd5dcea9f60244060b2b6a7c4365066e2060402fd8f36fce229"
+SHA256_PYTHON_SDK := "54aa3e33ebb45e03b5c13b86ce8742b45bb94e394925622fa66c4700f6782979"
+SHA256_PYTHON_SDK_BUILD := "98e7cd352e512d1d2af6f999f4391df959eba1b213ef778646353620d697638a"
 SHA256_WASI_SDK_SYSROOT := "35172f7d2799485b15a46b1d87f50a585d915ec662080f005d99153a50888f08"
 
 PYTHON_VERSION_FULL := PYTHON_VERSION_MAJOR + "." + PYTHON_VERSION_MINOR + "." + PYTHON_VERSION_MICRO
@@ -44,7 +44,7 @@ download-python-sdk:
         --tlsv1.2 \
         --location \
         --output "python-sdk.zip" \
-        "https://github.com/crepererum/cpython-wasi-build/releases/download/v{{PYTHON_VERSION_FULL}}/python-{{PYTHON_VERSION_FULL}}-wasi_sdk-{{WASI_SDK_VERSION_MAJOR}}.zip"
+        "https://github.com/brettcannon/cpython-wasi-build/releases/download/v{{PYTHON_VERSION_FULL}}/python-{{PYTHON_VERSION_FULL}}-wasi_sdk-{{WASI_SDK_VERSION_MAJOR}}.zip"
 
     curl \
         --fail \
@@ -54,7 +54,7 @@ download-python-sdk:
         --tlsv1.2 \
         --location \
         --output "build-python-sdk.zip" \
-        "https://github.com/crepererum/cpython-wasi-build/releases/download/v{{PYTHON_VERSION_FULL}}/_build-python-{{PYTHON_VERSION_FULL}}-wasi_sdk-{{WASI_SDK_VERSION_MAJOR}}.zip"
+        "https://github.com/brettcannon/cpython-wasi-build/releases/download/v{{PYTHON_VERSION_FULL}}/_build-python-{{PYTHON_VERSION_FULL}}-wasi_sdk-{{WASI_SDK_VERSION_MAJOR}}.zip"
 
     echo "{{SHA256_PYTHON_SDK}} python-sdk.zip" | sha256sum -c
     echo "{{SHA256_PYTHON_SDK_BUILD}} build-python-sdk.zip" | sha256sum -c

--- a/guests/python/README.md
+++ b/guests/python/README.md
@@ -14,7 +14,7 @@ just release
 ```
 
 ## Python Version
-We currently bundle [Python 3.14.0rc2].
+We currently bundle [Python 3.14.0].
 
 ## Python Standard Library
 In contrast to a normal Python installation there are a few notable public[^public] modules **missing** from the [Python Standard Library]:
@@ -199,7 +199,7 @@ There is NO I/O available that escapes the sandbox. The [Python Standard Library
 [`int`]: https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex
 [`Int64`]: https://docs.rs/arrow/latest/arrow/datatypes/enum.DataType.html#variant.Int64
 [`Microsecond`]: https://docs.rs/arrow/latest/arrow/datatypes/enum.TimeUnit.html#variant.Microsecond
-[Python 3.14.0rc2]: https://www.python.org/downloads/release/python-3140rc2/
+[Python 3.14.0]: https://www.python.org/downloads/release/python-3140
 [Python Standard Library]: https://docs.python.org/3/library/index.html
 [Scalar UDF]: https://docs.rs/datafusion/latest/datafusion/logical_expr/struct.ScalarUDF.html
 [`str`]: https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str


### PR DESCRIPTION
Now also uses the de facto standard WASI builds.

Closes #56.
