### PR TITLE
chore: speedup tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ cranelift-entity.opt-level = 3
 cranelift-frontend.opt-level = 3
 regalloc2.opt-level = 3
 wasmparser.opt-level = 3
+wasmtime-internal-cranelift.opt-level = 3
 
 # faster insta snapshots
 insta.opt-level = 3


### PR DESCRIPTION
Seems like some recent refactoring in `wasmtime` made our "optimize the crates even for tests" a bit outdated. For
`cargo test -- python::example` this reduces the time on my machine from about 16s to 10s.
