### PR TITLE
chore: group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,12 +6,18 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
-    ignore:
-      # We want to update arrow and datafusion manually
-      - dependency-name: "arrow"
-      - dependency-name: "arrow-*"
-      - dependency-name: "datafusion"
-      - dependency-name: "datafusion-*"
+    # NOTE: groups are "match first", and "unmatched dependencies have individual PRs"
+    groups:
+      arrow-and-datafusion:
+        patterns:
+          - "arrow"
+          - "arrow-*"
+          - "datafusion"
+          - "datafusion-*"
+      wasmtime:
+        patterns:
+          - "wasmtime"
+          - "wasmtime-*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
See #105 / #106 / #107, which all fail because `wasmtime` has to be upgraded in unison. Same goes for the Apache ecosystem crates, which I've converted from "ignore" to "update as a group".