### PR TITLE
fix: `Err` should not be a `dict` in Python

### DIFF
--- a/guests/python/src/python_modules/mod.rs
+++ b/guests/python/src/python_modules/mod.rs
@@ -1564,7 +1564,7 @@ mod wit_world {
         }
 
         #[pyclass]
-        #[derive(Debug, IntoPyObject)]
+        #[derive(Debug)]
         #[pyo3(extends = PyValueError, frozen, get_all, name = "Err", str)]
         pub(crate) struct ErrWrapper {
             value: Py<PyAny>,
@@ -1623,9 +1623,9 @@ mod wit_world {
         #[derive(Debug, IntoPyObject)]
         pub(crate) enum ResultWrapper {
             #[pyo3(transparent)]
-            Ok(OkWrapper),
+            Ok(Py<OkWrapper>),
             #[pyo3(transparent)]
-            Err(ErrWrapper),
+            Err(Py<ErrWrapper>),
         }
 
         impl ResultWrapper {
@@ -1635,26 +1635,30 @@ mod wit_world {
                 E: IntoPyObject<'py>,
             {
                 let res = match res {
-                    Ok(val) => Self::Ok(OkWrapper {
-                        value: val
+                    Ok(val) => {
+                        let val = val
                             .into_pyobject(py)
                             .map_err(|e| {
                                 let e: PyErr = e.into();
                                 e
                             })?
                             .into_any()
-                            .unbind(),
-                    }),
-                    Err(val) => Self::Err(ErrWrapper {
-                        value: val
+                            .unbind();
+
+                        Self::Ok(Py::new(py, OkWrapper { value: val })?)
+                    }
+                    Err(val) => {
+                        let val = val
                             .into_pyobject(py)
                             .map_err(|e| {
                                 let e: PyErr = e.into();
                                 e
                             })?
                             .into_any()
-                            .unbind(),
-                    }),
+                            .unbind();
+
+                        Self::Err(Py::new(py, ErrWrapper { value: val })?)
+                    }
                 };
                 Ok(res)
             }


### PR DESCRIPTION
Turns out `#[derive(IntoPyObject)]` for structs just creates a `dict`, which is not what we want. For the happy path that we tested so far, this doesn't make a difference, but in #112 I'm gonna test the error case (e.g. for rejected/blocked requests) and there the Python error interface actually matters. In fact without this change, `urllib3` trips over this with `AttributeError: 'dict' object has no attribute 'value'. Did you mean: 'values'?`.