### PR TITLE
fix: `str` representation of `value` of `OkWrapper`/`ErrWrapper`

### DIFF
--- a/guests/python/src/python_modules/error.rs
+++ b/guests/python/src/python_modules/error.rs
@@ -14,6 +14,20 @@ macro_rules! display_like_debug {
 
 pub(crate) use display_like_debug;
 
+/// Wrapper that forwards [`Debug`](std::fmt::Debug) to [`Display`](std::fmt::Display).
+pub(crate) struct DebugLikeDisplay<T>(pub(crate) T)
+where
+    T: std::fmt::Display;
+
+impl<T> std::fmt::Debug for DebugLikeDisplay<T>
+where
+    T: std::fmt::Display,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
 /// A resource (handle) was already used/moved/closed.
 #[derive(Debug, Default, Clone, Copy)]
 pub(crate) struct ResourceMoved;

--- a/guests/python/src/python_modules/mod.rs
+++ b/guests/python/src/python_modules/mod.rs
@@ -3,7 +3,7 @@ use pyo3::{BoundObject, exceptions::PyValueError, prelude::*};
 
 mod error;
 
-use error::{ResourceMoved, ResourceMovedOptionExt, display_like_debug};
+use error::{DebugLikeDisplay, ResourceMoved, ResourceMovedOptionExt, display_like_debug};
 
 /// Register python modules.
 ///
@@ -1536,6 +1536,7 @@ mod wit_world {
 
     #[pyo3::pymodule]
     pub(crate) mod types {
+
         use super::*;
 
         /// Hack: workaround for <https://github.com/PyO3/pyo3/issues/759>.
@@ -1559,7 +1560,9 @@ mod wit_world {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let Self { value } = self;
 
-                f.debug_struct("Ok").field("value", value).finish()
+                f.debug_struct("Ok")
+                    .field("value", &DebugLikeDisplay(value))
+                    .finish()
             }
         }
 
@@ -1574,7 +1577,9 @@ mod wit_world {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let Self { value } = self;
 
-                f.debug_struct("Err").field("value", value).finish()
+                f.debug_struct("Err")
+                    .field("value", &DebugLikeDisplay(value))
+                    .finish()
             }
         }
 


### PR DESCRIPTION
Turns out `std::fmt::Debug` for `Py<T>` isn't super helpful, one MUST use `std::fmt::Display` to get the actual Python `str`.

Found while working on #10.
