### PR TITLE
chore: avoid rebuilds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -808,6 +808,9 @@ dependencies = [
  "datafusion-common",
  "datafusion-expr",
  "datafusion-udf-wasm-arrow2bytes",
+ "libc",
+ "once_cell",
+ "syn",
  "wit-bindgen 0.47.0",
 ]
 
@@ -3356,9 +3359,6 @@ name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
-dependencies = [
- "bitflags",
-]
 
 [[package]]
 name = "wit-bindgen"
@@ -3366,6 +3366,7 @@ version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a374235c3c0dff10537040b437073d09f1e38f13216b5f3cbc809c6226814e5c"
 dependencies = [
+ "bitflags",
  "wit-bindgen-rust-macro",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,11 +29,12 @@ tokio = { version = "1.48.0", default-features = false }
 pyo3 = { version = "0.27.1", default-features = false, features = ["macros"] }
 tar = { version = "0.4.44", default-features = false }
 tempfile = { version = "3.23.0", default-features = false }
-wasip2 = { version = "1" }
+wasip2 = { version = "1", default-features = false }
 wasmtime = { version = "38.0.3", default-features = false, features = ["async", "cranelift"] }
 wasmtime-wasi = { version = "38.0.3", default-features = false }
 wasmtime-wasi-http = { version = "38.0.3", default-features = false, features = ["default-send-request"] }
-wit-bindgen = { version = "0.47", default-features = false, features = ["macros"] }
+# pull wit-bindgen/bitflags to reduce rebuilds
+wit-bindgen = { version = "0.47", default-features = false, features = ["bitflags", "macros"] }
 
 [workspace.lints.rust]
 missing_copy_implementations = "deny"

--- a/guests/rust/Cargo.toml
+++ b/guests/rust/Cargo.toml
@@ -15,6 +15,12 @@ datafusion-expr.workspace = true
 datafusion-udf-wasm-arrow2bytes.workspace = true
 wit-bindgen.workspace = true
 
+once_cell = { version = "1", default-features = false, features = ["alloc", "default", "race", "std"] }
+
+[build-dependencies]
+libc = { version = "0.2", default-features = false, features = ["default", "std"] }
+syn = { version = "2", default-features = false, features = ["clone-impls", "default", "derive", "extra-traits", "full", "parsing", "printing", "proc-macro", "visit-mut"] }
+
 [[example]]
 name = "add_one"
 crate-type = ["cdylib"]

--- a/guests/rust/src/lib.rs
+++ b/guests/rust/src/lib.rs
@@ -2,6 +2,10 @@
 //!
 //!
 //! [DataFusion]: https://datafusion.apache.org/
+
+// libs that we only pull in to avoid rebuilds / aid feature unification
+use once_cell as _;
+
 pub mod bindings;
 pub mod conversion;
 pub mod wrapper;


### PR DESCRIPTION
Tested with:

```console
$ just clean
$ CARGO_PROFILE_DEV_DEBUG=1 CARGO_INCREMENTAL=0 just check
$ du -s target
```

```text
base: 9_934_652
this: 9_488_804
```
