### PR TITLE
chore: manual WASI linking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -815,6 +815,7 @@ dependencies = [
 name = "datafusion-udf-wasm-host"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "arrow",
  "datafusion-common",
  "datafusion-expr",
@@ -829,6 +830,7 @@ dependencies = [
  "wasmtime",
  "wasmtime-wasi",
  "wasmtime-wasi-http",
+ "wasmtime-wasi-io",
  "wiremock",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
 resolver = "3"
 
 [workspace.dependencies]
+anyhow = { version = "1.0.100", default-features = false }
 arrow = { version = "55.2.0", default-features = false, features = ["ipc"] }
 chrono = { version = "0.4.42", default-features = false }
 datafusion-common = { version = "49.0.1", default-features = false }
@@ -33,6 +34,7 @@ wasip2 = { version = "1" }
 wasmtime = { version = "38.0.3", default-features = false, features = ["async", "cranelift"] }
 wasmtime-wasi = { version = "38.0.3", default-features = false }
 wasmtime-wasi-http = { version = "38.0.3", default-features = false, features = ["default-send-request"] }
+wasmtime-wasi-io = { version = "38.0.3", default-features = false }
 wit-bindgen = { version = "0.47", default-features = false, features = ["macros"] }
 
 [workspace.lints.rust]

--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 workspace = true
 
 [dependencies]
+anyhow.workspace = true
 arrow.workspace = true
 datafusion-common.workspace = true
 datafusion-expr.workspace = true
@@ -21,6 +22,7 @@ tokio = { workspace = true, features = ["rt", "rt-multi-thread", "sync"] }
 wasmtime.workspace = true
 wasmtime-wasi.workspace = true
 wasmtime-wasi-http.workspace = true
+wasmtime-wasi-io.workspace = true
 
 [dev-dependencies]
 datafusion-udf-wasm-bundle = { workspace = true, features = ["example", "python"] }

--- a/host/src/linker.rs
+++ b/host/src/linker.rs
@@ -1,0 +1,153 @@
+//! WebAssembly linker code.
+
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use wasmtime::{
+    Engine, Store,
+    component::{Component, HasData, Linker},
+};
+use wasmtime_wasi::{ResourceTable, WasiView};
+
+use crate::{WasmStateImpl, bindings::Datafusion};
+
+/// Link everything.
+pub(crate) async fn link(
+    engine: &Engine,
+    component: &Component,
+    state: WasmStateImpl,
+) -> Result<(Arc<Datafusion>, Store<WasmStateImpl>)> {
+    let mut store = Store::new(engine, state);
+
+    let mut linker = Linker::new(engine);
+    link_wasi_p2(&mut linker).context("link WASI p2")?;
+    wasmtime_wasi_http::add_only_http_to_linker_async(&mut linker)
+        .context("link WASI p2 HWasmStateImplWasmStateImplP")?;
+
+    let bindings = Arc::new(
+        Datafusion::instantiate_async(&mut store, component, &linker)
+            .await
+            .context("initialize bindings")?,
+    );
+    Ok((bindings, store))
+}
+
+/// Link WASIp2 interfaces.
+fn link_wasi_p2(linker: &mut Linker<WasmStateImpl>) -> Result<()> {
+    use wasmtime_wasi::{
+        cli::{WasiCli, WasiCliView},
+        clocks::{WasiClocks, WasiClocksView},
+        filesystem::{WasiFilesystem, WasiFilesystemView},
+        p2::bindings,
+        random::WasiRandom,
+        sockets::{WasiSockets, WasiSocketsView},
+    };
+
+    let options = bindings::LinkOptions::default();
+    wasmtime_wasi_io::bindings::wasi::io::error::add_to_linker::<WasmStateImpl, HasIo>(
+        linker,
+        |t| t.ctx().table,
+    )?;
+    wasmtime_wasi_io::bindings::wasi::io::poll::add_to_linker::<WasmStateImpl, HasIo>(
+        linker,
+        |t| t.ctx().table,
+    )?;
+    wasmtime_wasi_io::bindings::wasi::io::streams::add_to_linker::<WasmStateImpl, HasIo>(
+        linker,
+        |t| t.ctx().table,
+    )?;
+    bindings::clocks::wall_clock::add_to_linker::<WasmStateImpl, WasiClocks>(
+        linker,
+        WasmStateImpl::clocks,
+    )?;
+    bindings::clocks::monotonic_clock::add_to_linker::<WasmStateImpl, WasiClocks>(
+        linker,
+        WasmStateImpl::clocks,
+    )?;
+    bindings::cli::exit::add_to_linker::<WasmStateImpl, WasiCli>(
+        linker,
+        &(&options).into(),
+        WasmStateImpl::cli,
+    )?;
+    bindings::cli::environment::add_to_linker::<WasmStateImpl, WasiCli>(
+        linker,
+        WasmStateImpl::cli,
+    )?;
+    bindings::cli::stdin::add_to_linker::<WasmStateImpl, WasiCli>(linker, WasmStateImpl::cli)?;
+    bindings::cli::stdout::add_to_linker::<WasmStateImpl, WasiCli>(linker, WasmStateImpl::cli)?;
+    bindings::cli::stderr::add_to_linker::<WasmStateImpl, WasiCli>(linker, WasmStateImpl::cli)?;
+    bindings::cli::terminal_input::add_to_linker::<WasmStateImpl, WasiCli>(
+        linker,
+        WasmStateImpl::cli,
+    )?;
+    bindings::cli::terminal_output::add_to_linker::<WasmStateImpl, WasiCli>(
+        linker,
+        WasmStateImpl::cli,
+    )?;
+    bindings::cli::terminal_stdin::add_to_linker::<WasmStateImpl, WasiCli>(
+        linker,
+        WasmStateImpl::cli,
+    )?;
+    bindings::cli::terminal_stdout::add_to_linker::<WasmStateImpl, WasiCli>(
+        linker,
+        WasmStateImpl::cli,
+    )?;
+    bindings::cli::terminal_stderr::add_to_linker::<WasmStateImpl, WasiCli>(
+        linker,
+        WasmStateImpl::cli,
+    )?;
+    bindings::filesystem::types::add_to_linker::<WasmStateImpl, WasiFilesystem>(
+        linker,
+        WasmStateImpl::filesystem,
+    )?;
+    bindings::filesystem::preopens::add_to_linker::<WasmStateImpl, WasiFilesystem>(
+        linker,
+        WasmStateImpl::filesystem,
+    )?;
+    bindings::random::random::add_to_linker::<WasmStateImpl, WasiRandom>(linker, |t| {
+        t.ctx().ctx.random()
+    })?;
+    bindings::random::insecure::add_to_linker::<WasmStateImpl, WasiRandom>(linker, |t| {
+        t.ctx().ctx.random()
+    })?;
+    bindings::random::insecure_seed::add_to_linker::<WasmStateImpl, WasiRandom>(linker, |t| {
+        t.ctx().ctx.random()
+    })?;
+    bindings::sockets::instance_network::add_to_linker::<WasmStateImpl, WasiSockets>(
+        linker,
+        WasmStateImpl::sockets,
+    )?;
+    bindings::sockets::network::add_to_linker::<WasmStateImpl, WasiSockets>(
+        linker,
+        &(&options).into(),
+        WasmStateImpl::sockets,
+    )?;
+    bindings::sockets::ip_name_lookup::add_to_linker::<WasmStateImpl, WasiSockets>(
+        linker,
+        WasmStateImpl::sockets,
+    )?;
+    bindings::sockets::tcp::add_to_linker::<WasmStateImpl, WasiSockets>(
+        linker,
+        WasmStateImpl::sockets,
+    )?;
+    bindings::sockets::tcp_create_socket::add_to_linker::<WasmStateImpl, WasiSockets>(
+        linker,
+        WasmStateImpl::sockets,
+    )?;
+    bindings::sockets::udp::add_to_linker::<WasmStateImpl, WasiSockets>(
+        linker,
+        WasmStateImpl::sockets,
+    )?;
+    bindings::sockets::udp_create_socket::add_to_linker::<WasmStateImpl, WasiSockets>(
+        linker,
+        WasmStateImpl::sockets,
+    )?;
+    Ok(())
+}
+
+/// Marker struct to tell linker that we do in fact provide IO-related resource tables.
+struct HasIo;
+
+impl HasData for HasIo {
+    type Data<'a> = &'a mut ResourceTable;
+}


### PR DESCRIPTION
This pulls the upstream method that do everything automatically into our code base so we can control which components are linked. This is required to embed our own virtual file system in #126.