### PR TITLE
feat: expand test suite for Bytes, Date, Time, & TimeDelta

### DIFF
--- a/host/tests/integration_tests/python/types/date.rs
+++ b/host/tests/integration_tests/python/types/date.rs
@@ -105,3 +105,156 @@ def foo(x: date) -> date:
         @"Execution error: expected `date` but got `not a date` of type `str`",
     );
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_date_arithmetic_overflow() {
+    const CODE: &str = "
+from datetime import date, timedelta
+
+def foo(x: date) -> date:
+    try:
+        return x + timedelta(days=1000000)
+    except OverflowError:
+        return date(9999, 12, 31)
+";
+    let udf = python_scalar_udf(CODE).await.unwrap();
+
+    let array = udf
+        .invoke_with_args(ScalarFunctionArgs {
+            args: vec![ColumnarValue::Array(Arc::new(Date32Array::from_iter([
+                Some(0),     // 1970-01-01
+                Some(18000), // Some date in 2019
+            ])))],
+            arg_fields: vec![Arc::new(Field::new("a1", DataType::Date32, true))],
+            number_rows: 2,
+            return_field: Arc::new(Field::new("r", DataType::Date32, true)),
+        })
+        .unwrap()
+        .unwrap_array();
+
+    assert_eq!(array.len(), 2);
+    assert!(array.is_valid(0));
+    assert!(array.is_valid(1));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_date_string_formatting() {
+    const CODE: &str = "
+from datetime import date
+
+def foo(x: date) -> date:
+    date_str = x.strftime('%Y-%m-%d')
+    year, month, day = map(int, date_str.split('-'))
+    return date(year, month, day)
+";
+    let udf = python_scalar_udf(CODE).await.unwrap();
+
+    let array = udf
+        .invoke_with_args(ScalarFunctionArgs {
+            args: vec![ColumnarValue::Array(Arc::new(Date32Array::from_iter([
+                Some(0),     // 1970-01-01
+                Some(365),   // 1971-01-01
+                Some(19000), // 2022-01-04
+            ])))],
+            arg_fields: vec![Arc::new(Field::new("a1", DataType::Date32, true))],
+            number_rows: 3,
+            return_field: Arc::new(Field::new("r", DataType::Date32, true)),
+        })
+        .unwrap()
+        .unwrap_array();
+    assert_eq!(
+        array.as_ref(),
+        &Date32Array::from_iter([
+            Some(0), // Should be unchanged
+            Some(365),
+            Some(19000),
+        ]),
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_date_weekday_operations() {
+    const CODE: &str = "
+from datetime import date, timedelta
+
+def foo(x: date) -> date:
+    days_until_monday = (7 - x.weekday()) % 7
+    if days_until_monday == 0:
+        days_until_monday = 7
+    return x + timedelta(days=days_until_monday)
+";
+    let udf = python_scalar_udf(CODE).await.unwrap();
+
+    let array = udf
+        .invoke_with_args(ScalarFunctionArgs {
+            args: vec![ColumnarValue::Array(Arc::new(Date32Array::from_iter([
+                Some(0), // 1970-01-01 (Thursday)
+                Some(3), // 1970-01-04 (Sunday)
+                Some(4), // 1970-01-05 (Monday)
+            ])))],
+            arg_fields: vec![Arc::new(Field::new("a1", DataType::Date32, true))],
+            number_rows: 3,
+            return_field: Arc::new(Field::new("r", DataType::Date32, true)),
+        })
+        .unwrap()
+        .unwrap_array();
+
+    assert_eq!(array.len(), 3);
+    assert!(array.is_valid(0));
+    assert!(array.is_valid(1));
+    assert!(array.is_valid(2));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_invalid_date_construction() {
+    const CODE: &str = "
+from datetime import date
+
+def foo(x: date) -> date:
+    # Try to create invalid date
+    try:
+        return date(2021, 13, 32)
+    except ValueError:
+        return x  # Return original on error
+";
+    let udf = python_scalar_udf(CODE).await.unwrap();
+
+    let array = udf
+        .invoke_with_args(ScalarFunctionArgs {
+            args: vec![ColumnarValue::Array(Arc::new(Date32Array::from_iter([
+                Some(19000),
+            ])))],
+            arg_fields: vec![Arc::new(Field::new("a1", DataType::Date32, true))],
+            number_rows: 1,
+            return_field: Arc::new(Field::new("r", DataType::Date32, true)),
+        })
+        .unwrap()
+        .unwrap_array();
+    assert_eq!(array.as_ref(), &Date32Array::from_iter([Some(19000)]),);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_return_float() {
+    const CODE: &str = "
+from datetime import date
+
+def foo(x: date) -> date:
+    return 3.14
+";
+    let udf = python_scalar_udf(CODE).await.unwrap();
+
+    let err = udf
+        .invoke_with_args(ScalarFunctionArgs {
+            args: vec![ColumnarValue::Array(Arc::new(Date32Array::from_iter([
+                Some(0),
+            ])))],
+            arg_fields: vec![Arc::new(Field::new("a1", DataType::Date32, true))],
+            number_rows: 1,
+            return_field: Arc::new(Field::new("r", DataType::Date32, true)),
+        })
+        .unwrap_err();
+    insta::assert_snapshot!(
+        err,
+        @"Execution error: expected `date` but got `3.14` of type `float`",
+    );
+}

--- a/host/tests/integration_tests/python/types/time.rs
+++ b/host/tests/integration_tests/python/types/time.rs
@@ -144,7 +144,213 @@ def foo(x: time) -> time:
             )),
         })
         .unwrap_err();
-
+    // The error message will contain the actual datetime, so we just check it contains the expected type info
     assert!(err.to_string().contains("expected `time` but got"));
     assert!(err.to_string().contains("of type `datetime`"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_time_microsecond_precision() {
+    const CODE: &str = "
+from datetime import time
+
+def foo(x: time) -> time:
+    new_microsecond = (x.microsecond + 1) % 1000000
+    return x.replace(microsecond=new_microsecond)
+";
+    let udf = python_scalar_udf(CODE).await.unwrap();
+
+    let array = udf
+        .invoke_with_args(ScalarFunctionArgs {
+            args: vec![ColumnarValue::Array(Arc::new(
+                Time64MicrosecondArray::from_iter([
+                    Some(999_999),                         // 00:00:00.999999
+                    Some(12 * 3600 * 1_000_000 + 500_000), // 12:00:00.500000
+                ]),
+            ))],
+            arg_fields: vec![Arc::new(Field::new(
+                "a1",
+                DataType::Time64(TimeUnit::Microsecond),
+                true,
+            ))],
+            number_rows: 2,
+            return_field: Arc::new(Field::new(
+                "r",
+                DataType::Time64(TimeUnit::Microsecond),
+                true,
+            )),
+        })
+        .unwrap()
+        .unwrap_array();
+    assert_eq!(
+        array.as_ref(),
+        &Time64MicrosecondArray::from_iter([
+            Some(0),                               // 00:00:00.000000 (999999 + 1 wrapped to 0)
+            Some(12 * 3600 * 1_000_000 + 500_001), // 12:00:00.500001
+        ]),
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_time_arithmetic_with_overflow() {
+    const CODE: &str = "
+from datetime import time
+
+def foo(x: time) -> time:
+    total_seconds = x.hour * 3600 + x.minute * 60 + x.second
+    total_microseconds = total_seconds * 1000000 + x.microsecond
+    new_microseconds = (total_microseconds + 2 * 3600 * 1000000) % (24 * 3600 * 1000000)
+    
+    new_total_seconds = new_microseconds // 1000000
+    new_microsecond = new_microseconds % 1000000
+    
+    new_hour = (new_total_seconds // 3600) % 24
+    new_minute = (new_total_seconds % 3600) // 60
+    new_second = new_total_seconds % 60
+    
+    return time(new_hour, new_minute, new_second, new_microsecond)
+";
+    let udf = python_scalar_udf(CODE).await.unwrap();
+
+    let array = udf
+        .invoke_with_args(ScalarFunctionArgs {
+            args: vec![ColumnarValue::Array(Arc::new(
+                Time64MicrosecondArray::from_iter([
+                    Some(22 * 3600 * 1_000_000),                       // 22:00:00.000000
+                    Some(23 * 3600 * 1_000_000 + 30 * 60 * 1_000_000), // 23:30:00.000000
+                ]),
+            ))],
+            arg_fields: vec![Arc::new(Field::new(
+                "a1",
+                DataType::Time64(TimeUnit::Microsecond),
+                true,
+            ))],
+            number_rows: 2,
+            return_field: Arc::new(Field::new(
+                "r",
+                DataType::Time64(TimeUnit::Microsecond),
+                true,
+            )),
+        })
+        .unwrap()
+        .unwrap_array();
+    assert_eq!(
+        array.as_ref(),
+        &Time64MicrosecondArray::from_iter([
+            Some(0),                                      // 00:00:00.000000 (22 + 2 = 24, wrapped to 0)
+            Some(3600 * 1_000_000 + 30 * 60 * 1_000_000), // 01:30:00.000000 (23:30 + 2h = 01:30)
+        ]),
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_time_string_parsing() {
+    const CODE: &str = "
+from datetime import time
+
+def foo(x: time) -> time:
+    time_str = x.strftime('%H:%M:%S.%f')
+    hour, minute, second_micro = time_str.split(':')
+    second, microsecond = second_micro.split('.')
+    return time(int(hour), int(minute), int(second), int(microsecond))
+";
+    let udf = python_scalar_udf(CODE).await.unwrap();
+
+    let array = udf
+        .invoke_with_args(ScalarFunctionArgs {
+            args: vec![ColumnarValue::Array(Arc::new(
+                Time64MicrosecondArray::from_iter([Some(
+                    14 * 3600 * 1_000_000 + 25 * 60 * 1_000_000 + 30 * 1_000_000 + 123_456,
+                )]),
+            ))],
+            arg_fields: vec![Arc::new(Field::new(
+                "a1",
+                DataType::Time64(TimeUnit::Microsecond),
+                true,
+            ))],
+            number_rows: 1,
+            return_field: Arc::new(Field::new(
+                "r",
+                DataType::Time64(TimeUnit::Microsecond),
+                true,
+            )),
+        })
+        .unwrap()
+        .unwrap_array();
+    assert_eq!(
+        array.as_ref(),
+        &Time64MicrosecondArray::from_iter([Some(
+            14 * 3600 * 1_000_000 + 25 * 60 * 1_000_000 + 30 * 1_000_000 + 123_456
+        ),]),
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_invalid_time_construction() {
+    const CODE: &str = "
+from datetime import time
+
+def foo(x: time) -> time:
+    try:
+        return time(25, 70, 70)
+    except ValueError:
+        return x
+";
+    let udf = python_scalar_udf(CODE).await.unwrap();
+
+    let array = udf
+        .invoke_with_args(ScalarFunctionArgs {
+            args: vec![ColumnarValue::Array(Arc::new(
+                Time64MicrosecondArray::from_iter([Some(12 * 3600 * 1_000_000)]),
+            ))],
+            arg_fields: vec![Arc::new(Field::new(
+                "a1",
+                DataType::Time64(TimeUnit::Microsecond),
+                true,
+            ))],
+            number_rows: 1,
+            return_field: Arc::new(Field::new(
+                "r",
+                DataType::Time64(TimeUnit::Microsecond),
+                true,
+            )),
+        })
+        .unwrap()
+        .unwrap_array();
+    assert_eq!(
+        array.as_ref(),
+        &Time64MicrosecondArray::from_iter([Some(12 * 3600 * 1_000_000)]),
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_return_timedelta() {
+    const CODE: &str = "
+from datetime import time, timedelta
+
+def foo(x: time) -> time:
+    return timedelta(hours=1)
+";
+    let udf = python_scalar_udf(CODE).await.unwrap();
+
+    let err = udf
+        .invoke_with_args(ScalarFunctionArgs {
+            args: vec![ColumnarValue::Array(Arc::new(
+                Time64MicrosecondArray::from_iter([Some(0)]),
+            ))],
+            arg_fields: vec![Arc::new(Field::new(
+                "a1",
+                DataType::Time64(TimeUnit::Microsecond),
+                true,
+            ))],
+            number_rows: 1,
+            return_field: Arc::new(Field::new(
+                "r",
+                DataType::Time64(TimeUnit::Microsecond),
+                true,
+            )),
+        })
+        .unwrap_err();
+    assert!(err.to_string().contains("expected `time` but got"));
+    assert!(err.to_string().contains("of type `timedelta`"));
 }

--- a/host/tests/integration_tests/python/types/timedelta.rs
+++ b/host/tests/integration_tests/python/types/timedelta.rs
@@ -137,7 +137,7 @@ def foo(x: timedelta) -> timedelta:
             )),
         })
         .unwrap_err();
-
+    // The error message will contain the actual datetime, so we just check it contains the expected type info
     assert!(err.to_string().contains("expected `timedelta` but got"));
     assert!(err.to_string().contains("of type `datetime`"));
 }
@@ -173,5 +173,243 @@ def foo(x: timedelta) -> timedelta:
     insta::assert_snapshot!(
         err,
         @"Execution error: expected `timedelta` but got `42` of type `int`",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_timedelta_fractional_seconds() {
+    const CODE: &str = "
+from datetime import timedelta
+
+def foo(x: timedelta) -> timedelta:
+    total_seconds = x.total_seconds()
+    new_seconds = total_seconds + 0.5
+    return timedelta(seconds=new_seconds)
+";
+    let udf = python_scalar_udf(CODE).await.unwrap();
+
+    let array = udf
+        .invoke_with_args(ScalarFunctionArgs {
+            args: vec![ColumnarValue::Array(Arc::new(
+                DurationMicrosecondArray::from_iter([
+                    Some(1_500_000),  // 1.5 seconds
+                    Some(0),          // 0 seconds
+                    Some(-2_000_000), // -2 seconds
+                ]),
+            ))],
+            arg_fields: vec![Arc::new(Field::new(
+                "a1",
+                DataType::Duration(TimeUnit::Microsecond),
+                true,
+            ))],
+            number_rows: 3,
+            return_field: Arc::new(Field::new(
+                "r",
+                DataType::Duration(TimeUnit::Microsecond),
+                true,
+            )),
+        })
+        .unwrap()
+        .unwrap_array();
+    assert_eq!(
+        array.as_ref(),
+        &DurationMicrosecondArray::from_iter([
+            Some(2_000_000),  // 2.0 seconds (1.5 + 0.5)
+            Some(500_000),    // 0.5 seconds (0 + 0.5)
+            Some(-1_500_000), // -1.5 seconds (-2 + 0.5)
+        ]),
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_timedelta_arithmetic_operations() {
+    const CODE: &str = "
+from datetime import timedelta
+
+def foo(x: timedelta) -> timedelta:
+    one_hour = timedelta(hours=1)
+    one_day = timedelta(days=1)
+    
+    result = x * 2 + one_hour - one_day
+    return result
+";
+    let udf = python_scalar_udf(CODE).await.unwrap();
+
+    let array = udf
+        .invoke_with_args(ScalarFunctionArgs {
+            args: vec![ColumnarValue::Array(Arc::new(
+                DurationMicrosecondArray::from_iter([
+                    Some(3600 * 1_000_000),      // 1 hour
+                    Some(12 * 3600 * 1_000_000), // 12 hours
+                    Some(-1800 * 1_000_000),     // -30 minutes
+                ]),
+            ))],
+            arg_fields: vec![Arc::new(Field::new(
+                "a1",
+                DataType::Duration(TimeUnit::Microsecond),
+                true,
+            ))],
+            number_rows: 3,
+            return_field: Arc::new(Field::new(
+                "r",
+                DataType::Duration(TimeUnit::Microsecond),
+                true,
+            )),
+        })
+        .unwrap()
+        .unwrap_array();
+
+    // Expected: x*2 + 1hour - 1day
+    // For 1 hour: 2*1h + 1h - 24h = -21h = -75600 seconds
+    // For 12 hours: 2*12h + 1h - 24h = 1h = 3600 seconds
+    // For -30 min: 2*(-30min) + 1h - 24h = -1h - 24h = -25h = -90000 seconds
+    assert_eq!(
+        array.as_ref(),
+        &DurationMicrosecondArray::from_iter([
+            Some(-75600 * 1_000_000), // -21 hours
+            Some(3600 * 1_000_000),   // 1 hour
+            Some(-90000 * 1_000_000), // -25 hours
+        ]),
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_timedelta_division_operations() {
+    const CODE: &str = "
+from datetime import timedelta
+
+def foo(x: timedelta) -> timedelta:
+    if x.total_seconds() != 0:
+        return x / 2
+    else:
+        return timedelta(seconds=1)
+";
+    let udf = python_scalar_udf(CODE).await.unwrap();
+
+    let array = udf
+        .invoke_with_args(ScalarFunctionArgs {
+            args: vec![ColumnarValue::Array(Arc::new(
+                DurationMicrosecondArray::from_iter([
+                    Some(3600 * 1_000_000),  // 1 hour
+                    Some(0),                 // 0 seconds
+                    Some(-7200 * 1_000_000), // -2 hours
+                ]),
+            ))],
+            arg_fields: vec![Arc::new(Field::new(
+                "a1",
+                DataType::Duration(TimeUnit::Microsecond),
+                true,
+            ))],
+            number_rows: 3,
+            return_field: Arc::new(Field::new(
+                "r",
+                DataType::Duration(TimeUnit::Microsecond),
+                true,
+            )),
+        })
+        .unwrap()
+        .unwrap_array();
+    assert_eq!(
+        array.as_ref(),
+        &DurationMicrosecondArray::from_iter([
+            Some(1800 * 1_000_000),  // 30 minutes (1h / 2)
+            Some(1_000_000),         // 1 second (0 -> 1s)
+            Some(-3600 * 1_000_000), // -1 hour (-2h / 2)
+        ]),
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_timedelta_string_representation() {
+    const CODE: &str = "
+from datetime import timedelta
+
+def foo(x: timedelta) -> timedelta:
+    str_repr = str(x)
+    if 'day' in str_repr:
+        return timedelta(days=1)
+    else:
+        return x * 2
+";
+    let udf = python_scalar_udf(CODE).await.unwrap();
+
+    let array = udf
+        .invoke_with_args(ScalarFunctionArgs {
+            args: vec![ColumnarValue::Array(Arc::new(
+                DurationMicrosecondArray::from_iter([
+                    Some(3600 * 1_000_000),       // 1 hour
+                    Some(25 * 3600 * 1_000_000),  // 25 hours (> 1 day)
+                    Some(-12 * 3600 * 1_000_000), // -12 hours
+                ]),
+            ))],
+            arg_fields: vec![Arc::new(Field::new(
+                "a1",
+                DataType::Duration(TimeUnit::Microsecond),
+                true,
+            ))],
+            number_rows: 3,
+            return_field: Arc::new(Field::new(
+                "r",
+                DataType::Duration(TimeUnit::Microsecond),
+                true,
+            )),
+        })
+        .unwrap()
+        .unwrap_array();
+
+    assert_eq!(array.len(), 3);
+    assert!(array.is_valid(0));
+    assert!(array.is_valid(1));
+    assert!(array.is_valid(2));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_timedelta_comparison_operations() {
+    const CODE: &str = "
+from datetime import timedelta
+
+def foo(x: timedelta) -> timedelta:
+    zero = timedelta(0)
+    one_hour = timedelta(hours=1)
+    
+    if x > one_hour:
+        return timedelta(hours=24)
+    elif x < zero:
+        return timedelta(0)
+    else:
+        return one_hour
+";
+    let udf = python_scalar_udf(CODE).await.unwrap();
+
+    let array = udf
+        .invoke_with_args(ScalarFunctionArgs {
+            args: vec![ColumnarValue::Array(Arc::new(
+                DurationMicrosecondArray::from_iter([
+                    Some(7200 * 1_000_000),  // 2 hours (> 1 hour)
+                    Some(-1800 * 1_000_000), // -30 minutes (< 0)
+                    Some(1800 * 1_000_000),  // 30 minutes (0 < x < 1 hour)
+                ]),
+            ))],
+            arg_fields: vec![Arc::new(Field::new(
+                "a1",
+                DataType::Duration(TimeUnit::Microsecond),
+                true,
+            ))],
+            number_rows: 3,
+            return_field: Arc::new(Field::new(
+                "r",
+                DataType::Duration(TimeUnit::Microsecond),
+                true,
+            )),
+        })
+        .unwrap()
+        .unwrap_array();
+    assert_eq!(
+        array.as_ref(),
+        &DurationMicrosecondArray::from_iter([
+            Some(24 * 3600 * 1_000_000), // 24 hours
+            Some(0),                     // 0
+            Some(3600 * 1_000_000),      // 1 hour
+        ]),
     );
 }


### PR DESCRIPTION
Expands the test suite for the listed scalar types. I wasn't sure if the tests in #139 were extensive enough, which is why I've filed this PR.

- [ ] I've read the contributing section of the project [CONTRIBUTING.md](https://github.com/influxdata/datafusion-udf-wasm/blob/main/CONTRIBUTING.md).
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
