### PR TITLE
feat: re-export `http::Method`

### DIFF
--- a/host/src/http.rs
+++ b/host/src/http.rs
@@ -2,7 +2,7 @@
 
 use std::{borrow::Cow, collections::HashSet, fmt};
 
-use http::Method;
+pub use http::Method;
 use wasmtime_wasi_http::body::HyperOutgoingBody;
 
 /// Validates if an outgoing HTTP interaction is allowed.


### PR DESCRIPTION
Technically we would need to re-export way more stuff to allow people to implement `HttpRequestValidator` without extra dependencies, but that seems like a never-ending tail. However `Method` is used by our simple `Matcher`/`AllowCertainHttpRequests` and I feel that at least they should work without fudging with more dependencies.

Also note that there's currently NO clippy lint for that: https://github.com/rust-lang/rust-clippy/issues/2848