### PR TITLE
chore: add `sqlparser` to `apache` dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,12 +8,13 @@ updates:
     open-pull-requests-limit: 10
     # NOTE: groups are "match first", and "unmatched dependencies have individual PRs"
     groups:
-      arrow-and-datafusion:
+      apache:
         patterns:
           - "arrow"
           - "arrow-*"
           - "datafusion"
           - "datafusion-*"
+          - "sqlparser"
       wasmtime:
         patterns:
           - "wasmtime"


### PR DESCRIPTION
See #142 for a somewhat failed attempt to upgrade it.
