### PR TITLE
chore: fix json schema URL

### DIFF
--- a/tombi.toml
+++ b/tombi.toml
@@ -1,2 +1,9 @@
 [files]
 exclude = [".jj/**/*.toml", "target/**/*.toml"]
+
+[schema]
+catalog = {
+  paths = [
+    "https://www.schemastore.org/api/json/catalog.json",
+  ],
+}


### PR DESCRIPTION
Our TOML linting currently fails with:

```text
Error: failed to fetch catalog: https://json.schemastore.org/api/json/catalog.json, reason: unexpected status: 503
```

Setting the store URL to the actual new location helps.

Also see https://github.com/SchemaStore/schemastore/issues/5106 .