### PR TITLE
feat: logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1273,6 +1273,7 @@ dependencies = [
  "http",
  "hyper",
  "insta",
+ "log",
  "rand 0.9.2",
  "siphasher",
  "tar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ datafusion-udf-wasm-query = { path = "query", version = "0.1.0" }
 http = { version = "1.3.1", default-features = false }
 hyper = { version = "1.7", default-features = false }
 insta = { version = "1.43.2", "default-features" = false }
+log = { version = "0.4.28", default-features = false }
 pyo3 = { version = "0.27.1", default-features = false, features = ["macros"] }
 sqlparser = { version = "0.55.0", default-features = false, features = [
   "std",

--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -12,6 +12,7 @@ datafusion-expr.workspace = true
 datafusion-udf-wasm-arrow2bytes.workspace = true
 http.workspace = true
 hyper.workspace = true
+log.workspace = true
 rand = { version = "0.9" }
 siphasher = { version = "1", default-features = false }
 tar.workspace = true

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -131,6 +131,11 @@ impl WasiHttpView for WasmStateImpl {
                     .validate(&request, config.use_tls)
                     .map_err(|_| HttpErrorCode::HttpRequestDenied)?;
 
+                log::debug!(
+                    "UDF HTTP request: {} {}",
+                    request.method().as_str(),
+                    request.uri(),
+                );
                 default_send_request_handler(request, config).await
             };
 
@@ -190,6 +195,12 @@ impl WasmComponentPrecompiled {
             let compiled_component = engine
                 .precompile_component(&wasm_binary)
                 .context("pre-compile component", None)?;
+
+            log::debug!(
+                "Pre-compiled {} bytes of WASM bytecode into {} bytes",
+                wasm_binary.len(),
+                compiled_component.len()
+            );
 
             // SAFETY: the compiled version was produced by us with the same engine. This is NOT external/untrusted input.
             let component_res = unsafe { Component::deserialize(&engine, compiled_component) };

--- a/host/src/vfs.rs
+++ b/host/src/vfs.rs
@@ -214,6 +214,11 @@ impl Allocation {
         }
     }
 
+    /// Get current allocation size.
+    fn get(&self) -> u64 {
+        self.n.load(Ordering::SeqCst)
+    }
+
     /// Increase allocation by given amount.
     fn inc(&self, n: u64) -> Result<(), FailedAllocation> {
         self.n
@@ -403,6 +408,13 @@ impl VfsState {
                 }
             }
         }
+
+        log::info!(
+            "unpacked WASM guest root filesystem from {} bytes TAR, consuming {} bytes and {} inodes",
+            tar_data.len(),
+            self.allocation.bytes.get(),
+            self.allocation.inodes.get()
+        );
 
         Ok(())
     }


### PR DESCRIPTION
Some simple logging that help debugging and operating.

This uses `log` instead of `tracing` because

- `log` is used by DataFusion
- currently `log` is better maintained than `tracing`