### PR TITLE
feat: Python `None`/null support

### DIFF
--- a/guests/python/README.md
+++ b/guests/python/README.md
@@ -63,6 +63,7 @@ Types are mapped to/from [Apache Arrow] as follows:
 | [`datetime`] | [`Timestamp`] w/ [`Microsecond`] and NO timezone |
 | [`float`]    | [`Float64`] |
 | [`int`]      | [`Int64`]   |
+| [`None`]     | [`Null`]   |
 | [`str`]      | [`Utf8`]    |
 | [`time`]     | [`Time64`] w/ [`Microsecond`] and NO timezone |
 | [`timedelta`]| [`Duration`]      |
@@ -206,6 +207,8 @@ There is NO I/O available that escapes the sandbox. The [Python Standard Library
 [`functools.cache`]: https://docs.python.org/3/library/functools.html#functools.cache
 [`int`]: https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex
 [`Int64`]: https://docs.rs/arrow/latest/arrow/datatypes/enum.DataType.html#variant.Int64
+[`None`]: https://docs.python.org/3/library/constants.html#None
+[`Null`]: https://docs.rs/arrow/latest/arrow/datatypes/enum.DataType.html#variant.Null
 [`time`]: https://docs.python.org/3/library/datetime.html#datetime.time
 [`Time64`]: https://docs.rs/arrow/latest/arrow/datatypes/enum.DataType.html#variant.Time64
 [`timedelta`]: https://docs.python.org/3/library/datetime.html#datetime.timedelta

--- a/guests/python/src/signature.rs
+++ b/guests/python/src/signature.rs
@@ -8,7 +8,7 @@ use pyo3::{Py, PyAny};
 /// # Naming
 /// Since Python and Arrow use different names for the same type, we have to settle on some consistency. We chose to
 /// use the Python name in CamelCase style, so Python's `datetime` will become `DateTime`.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq, Hash)]
 pub(crate) enum PythonType {
     /// Boolean.
     ///
@@ -81,6 +81,18 @@ pub(crate) enum PythonType {
     /// # Arrow
     /// We map this to [`Int64`](arrow::datatypes::DataType::Int64).
     Int,
+
+    /// None/Null.
+    ///
+    /// # Python
+    /// The type is called `None`, documentation can be found here:
+    ///
+    /// - <https://docs.python.org/3/library/constants.html#None>
+    /// - <https://docs.python.org/3/library/types.html#types.NoneType>
+    ///
+    /// # Arrow
+    /// We map this to [`Null`](https://docs.rs/arrow/latest/arrow/datatypes/enum.DataType.html#variant.Null).
+    None,
 
     /// String.
     ///

--- a/host/tests/integration_tests/python/inspection/errors.rs
+++ b/host/tests/integration_tests/python/inspection/errors.rs
@@ -80,7 +80,82 @@ def add_one(x: int | str) -> int:
         @r"
     scalar_udfs
     caused by
-    Error during planning: TypeError: only unions with None are supported
+    Error during planning: TypeError: only unions of form `T | None` are suppored, but got a union of 2 distinct none-NULL types
+
+    The above exception was the direct cause of the following exception:
+
+    TypeError: inspect parameter 1
+
+    The above exception was the direct cause of the following exception:
+
+    TypeError: inspect type of `add_one`
+    ",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_union_type_2_and_none() {
+    const CODE: &str = "
+def add_one(x: int | str | None) -> int:
+    return x + 1
+";
+
+    insta::assert_snapshot!(
+        err(CODE).await,
+        @r"
+    scalar_udfs
+    caused by
+    Error during planning: TypeError: only unions of form `T | None` are suppored, but got a union of 2 distinct none-NULL types
+
+    The above exception was the direct cause of the following exception:
+
+    TypeError: inspect parameter 1
+
+    The above exception was the direct cause of the following exception:
+
+    TypeError: inspect type of `add_one`
+    ",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_union_type_2_identical() {
+    const CODE: &str = "
+def add_one(x: int | str | int) -> int:
+    return x + 1
+";
+
+    insta::assert_snapshot!(
+        err(CODE).await,
+        @r"
+    scalar_udfs
+    caused by
+    Error during planning: TypeError: only unions of form `T | None` are suppored, but got a union of 2 distinct none-NULL types
+
+    The above exception was the direct cause of the following exception:
+
+    TypeError: inspect parameter 1
+
+    The above exception was the direct cause of the following exception:
+
+    TypeError: inspect type of `add_one`
+    ",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_union_type_2_identical_and_none() {
+    const CODE: &str = "
+def add_one(x: int | None | str | int) -> int:
+    return x + 1
+";
+
+    insta::assert_snapshot!(
+        err(CODE).await,
+        @r"
+    scalar_udfs
+    caused by
+    Error during planning: TypeError: only unions of form `T | None` are suppored, but got a union of 2 distinct none-NULL types
 
     The above exception was the direct cause of the following exception:
 
@@ -96,7 +171,7 @@ def add_one(x: int | str) -> int:
 #[tokio::test(flavor = "multi_thread")]
 async fn test_union_type_3() {
     const CODE: &str = "
-def add_one(x: int | str | None) -> int:
+def add_one(x: int | str | float) -> int:
     return x + 1
 ";
 
@@ -105,7 +180,7 @@ def add_one(x: int | str | None) -> int:
         @r"
     scalar_udfs
     caused by
-    Error during planning: TypeError: only unions of length 2 are supported, got 3
+    Error during planning: TypeError: only unions of form `T | None` are suppored, but got a union of 3 distinct none-NULL types
 
     The above exception was the direct cause of the following exception:
 

--- a/host/tests/integration_tests/python/types/mod.rs
+++ b/host/tests/integration_tests/python/types/mod.rs
@@ -4,6 +4,8 @@ mod date;
 mod datetime;
 mod float;
 mod int;
+mod none;
 mod str;
 mod time;
 mod timedelta;
+mod union;

--- a/host/tests/integration_tests/python/types/none.rs
+++ b/host/tests/integration_tests/python/types/none.rs
@@ -1,0 +1,169 @@
+use std::sync::Arc;
+
+use arrow::{
+    array::{Array, NullArray},
+    datatypes::{DataType, Field},
+};
+use datafusion_expr::{ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility};
+
+use crate::integration_tests::{
+    python::test_utils::python_scalar_udf, test_utils::ColumnarValueExt,
+};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_ok() {
+    const CODE: &str = "
+def foo(x: None) -> None:
+    return None
+";
+    let udf = python_scalar_udf(CODE).await.unwrap();
+
+    assert_eq!(
+        udf.signature(),
+        &Signature::exact(vec![DataType::Null], Volatility::Volatile),
+    );
+
+    assert_eq!(udf.return_type(&[DataType::Null]).unwrap(), DataType::Null,);
+
+    let array = udf
+        .invoke_with_args(ScalarFunctionArgs {
+            args: vec![ColumnarValue::Array(Arc::new(NullArray::new(3)))],
+            arg_fields: vec![Arc::new(Field::new("a1", DataType::Null, true))],
+            number_rows: 3,
+            return_field: Arc::new(Field::new("r", DataType::Null, true)),
+        })
+        .unwrap()
+        .unwrap_array();
+    assert_eq!(array.as_ref(), &NullArray::new(3) as &dyn Array,);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_implicit_return_pass() {
+    const CODE: &str = "
+def foo() -> None:
+    pass
+";
+    let udf = python_scalar_udf(CODE).await.unwrap();
+
+    let array = udf
+        .invoke_with_args(ScalarFunctionArgs {
+            args: vec![],
+            arg_fields: vec![],
+            number_rows: 3,
+            return_field: Arc::new(Field::new("r", DataType::Null, true)),
+        })
+        .unwrap()
+        .unwrap_array();
+    assert_eq!(array.as_ref(), &NullArray::new(3) as &dyn Array,);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_implicit_return_ellipsis() {
+    const CODE: &str = "
+def foo() -> None:
+    ...
+";
+    let udf = python_scalar_udf(CODE).await.unwrap();
+
+    let array = udf
+        .invoke_with_args(ScalarFunctionArgs {
+            args: vec![],
+            arg_fields: vec![],
+            number_rows: 3,
+            return_field: Arc::new(Field::new("r", DataType::Null, true)),
+        })
+        .unwrap()
+        .unwrap_array();
+    assert_eq!(array.as_ref(), &NullArray::new(3) as &dyn Array,);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_implicit_return_docstring() {
+    const CODE: &str = r#"
+def foo() -> None:
+    """
+    Some docs.
+    """
+"#;
+    let udf = python_scalar_udf(CODE).await.unwrap();
+
+    let array = udf
+        .invoke_with_args(ScalarFunctionArgs {
+            args: vec![],
+            arg_fields: vec![],
+            number_rows: 3,
+            return_field: Arc::new(Field::new("r", DataType::Null, true)),
+        })
+        .unwrap()
+        .unwrap_array();
+    assert_eq!(array.as_ref(), &NullArray::new(3) as &dyn Array,);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_err_zero_returned() {
+    const CODE: &str = "
+def foo() -> None:
+    return 0
+";
+    let udf = python_scalar_udf(CODE).await.unwrap();
+
+    let err = udf
+        .invoke_with_args(ScalarFunctionArgs {
+            args: vec![],
+            arg_fields: vec![],
+            number_rows: 3,
+            return_field: Arc::new(Field::new("r", DataType::Null, true)),
+        })
+        .unwrap_err();
+
+    insta::assert_snapshot!(
+        err,
+        @"Execution error: expected `None` but got `0` of type `int`",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_err_false_returned() {
+    const CODE: &str = "
+def foo() -> None:
+    return False
+";
+    let udf = python_scalar_udf(CODE).await.unwrap();
+
+    let err = udf
+        .invoke_with_args(ScalarFunctionArgs {
+            args: vec![],
+            arg_fields: vec![],
+            number_rows: 3,
+            return_field: Arc::new(Field::new("r", DataType::Null, true)),
+        })
+        .unwrap_err();
+
+    insta::assert_snapshot!(
+        err,
+        @"Execution error: expected `None` but got `False` of type `bool`",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_err_empty_tuple_returned() {
+    const CODE: &str = "
+def foo() -> None:
+    return ()
+";
+    let udf = python_scalar_udf(CODE).await.unwrap();
+
+    let err = udf
+        .invoke_with_args(ScalarFunctionArgs {
+            args: vec![],
+            arg_fields: vec![],
+            number_rows: 3,
+            return_field: Arc::new(Field::new("r", DataType::Null, true)),
+        })
+        .unwrap_err();
+
+    insta::assert_snapshot!(
+        err,
+        @"Execution error: expected `None` but got `()` of type `tuple`",
+    );
+}

--- a/host/tests/integration_tests/python/types/union.rs
+++ b/host/tests/integration_tests/python/types/union.rs
@@ -1,0 +1,46 @@
+use arrow::datatypes::DataType;
+use datafusion_expr::{ScalarUDFImpl, Signature, Volatility};
+
+use crate::integration_tests::python::test_utils::python_scalar_udf;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_reduction_bool() {
+    const CODE: &str = "
+def foo(x: bool | None | bool | None) -> None:
+    pass
+";
+    let udf = python_scalar_udf(CODE).await.unwrap();
+
+    assert_eq!(
+        udf.signature(),
+        &Signature::exact(vec![DataType::Boolean], Volatility::Volatile),
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_reduction_int() {
+    const CODE: &str = "
+def foo(x: int | None | int | None) -> None:
+    pass
+";
+    let udf = python_scalar_udf(CODE).await.unwrap();
+
+    assert_eq!(
+        udf.signature(),
+        &Signature::exact(vec![DataType::Int64], Volatility::Volatile),
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_reduction_str() {
+    const CODE: &str = "
+def foo(x: str | None | str | None) -> None:
+    pass
+";
+    let udf = python_scalar_udf(CODE).await.unwrap();
+
+    assert_eq!(
+        udf.signature(),
+        &Signature::exact(vec![DataType::Utf8], Volatility::Volatile),
+    );
+}


### PR DESCRIPTION
This allows people to write methods that don't return anything, like:

```python
import requests

def log(x: int) -> None:
    requests.post("http://localhost:1234/", data={"x": x})
```
