### PR TITLE
feat: infrastructure for "evil" test payloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1244,9 +1244,21 @@ dependencies = [
 name = "datafusion-udf-wasm-bundle"
 version = "0.1.0"
 dependencies = [
+ "datafusion-udf-wasm-evil",
  "datafusion-udf-wasm-guest",
  "datafusion-udf-wasm-python",
  "serde_json",
+]
+
+[[package]]
+name = "datafusion-udf-wasm-evil"
+version = "0.1.0"
+dependencies = [
+ "arrow",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-udf-wasm-guest",
+ "tar",
 ]
 
 [[package]]
@@ -1275,6 +1287,7 @@ dependencies = [
  "insta",
  "log",
  "rand 0.9.2",
+ "regex",
  "siphasher",
  "tar",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "3"
 members = [
   "arrow2bytes",
   "guests/bundle",
+  "guests/evil",
   "guests/python",
   "guests/rust",
   "host",
@@ -24,6 +25,7 @@ datafusion-expr = { version = "49.0.1", default-features = false }
 datafusion-sql = { version = "49.0.1", default-features = false }
 datafusion-udf-wasm-arrow2bytes = { path = "arrow2bytes", version = "0.1.0" }
 datafusion-udf-wasm-bundle = { path = "guests/bundle", version = "0.1.0" }
+datafusion-udf-wasm-evil = { path = "guests/evil", version = "0.1.0" }
 datafusion-udf-wasm-guest = { path = "guests/rust", version = "0.1.0" }
 datafusion-udf-wasm-host = { path = "host", version = "0.1.0" }
 datafusion-udf-wasm-python = { path = "guests/python", version = "0.1.0" }
@@ -33,6 +35,7 @@ hyper = { version = "1.8", default-features = false }
 insta = { version = "1.43.2", "default-features" = false }
 log = { version = "0.4.28", default-features = false }
 pyo3 = { version = "0.27.1", default-features = false, features = ["macros"] }
+regex = { version = "1", default-features = false }
 sqlparser = { version = "0.55.0", default-features = false, features = [
   "std",
   "visitor"

--- a/guests/Justfile
+++ b/guests/Justfile
@@ -1,2 +1,3 @@
+mod evil
 mod python
 mod rust

--- a/guests/bundle/Cargo.toml
+++ b/guests/bundle/Cargo.toml
@@ -6,12 +6,14 @@ license.workspace = true
 
 [build-dependencies]
 # these need to be marked as build dependencies so the build script reruns whenever they change
+datafusion-udf-wasm-evil = { workspace = true, optional = true }
 datafusion-udf-wasm-guest = { workspace = true, optional = true }
 datafusion-udf-wasm-python = { workspace = true, optional = true }
 # the actual build-time dependencies
 serde_json = "1.0.145"
 
 [features]
+evil = ["dep:datafusion-udf-wasm-evil"]
 example = ["dep:datafusion-udf-wasm-guest"]
 python = ["dep:datafusion-udf-wasm-python"]
 

--- a/guests/bundle/build.rs
+++ b/guests/bundle/build.rs
@@ -288,6 +288,15 @@ fn just_build(cwd: &Path, just_cmd: &str, cargo_target_dir: &Path) {
 /// This must be in-sync with the feature list in `Cargo.toml`.
 const FEATURES: &[Feature] = &[
     Feature {
+        name: "evil",
+        package: "datafusion-udf-wasm-evil",
+        just_cmds: &[JustCmd {
+            artifact_type: ArtifactType::Lib,
+            const_name: "EVIL",
+            doc: "Evil payloads.",
+        }],
+    },
+    Feature {
         name: "example",
         package: "datafusion-udf-wasm-guest",
         just_cmds: &[JustCmd {

--- a/guests/evil/Cargo.toml
+++ b/guests/evil/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "datafusion-udf-wasm-evil"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+arrow.workspace = true
+datafusion-common.workspace = true
+datafusion-expr.workspace = true
+datafusion-udf-wasm-guest.workspace = true
+tar.workspace = true
+
+[lints]
+workspace = true

--- a/guests/evil/Justfile
+++ b/guests/evil/Justfile
@@ -1,0 +1,14 @@
+[private]
+build profile:
+    @echo ::group::guests::evil::build-{{profile}}
+    cargo build --target=wasm32-wasip2 --profile={{replace(profile, "debug", "dev")}}
+    @echo ::endgroup::
+
+# build library in debug mode
+build-debug: (build "debug")
+
+# build library in release mode
+build-release: (build "release")
+
+# checks build
+check-build: build-debug

--- a/guests/evil/README.md
+++ b/guests/evil/README.md
@@ -1,0 +1,5 @@
+# Evil Test Payloads
+
+These are payloads that try to stress the WASM sandbox. They are NOT meant to be used in production.
+
+For efficiency we generate a single WASM binary that is multiplexed using the `EVIL` environment variable.

--- a/guests/evil/src/lib.rs
+++ b/guests/evil/src/lib.rs
@@ -1,0 +1,58 @@
+//! Library that multiplexes different evil payloads.
+//!
+//! We need that because evil payloads may act long before the actual UDFs are available.
+use std::sync::Arc;
+
+use datafusion_common::Result as DataFusionResult;
+use datafusion_expr::ScalarUDFImpl;
+use datafusion_udf_wasm_guest::export;
+
+mod root;
+mod runtime;
+
+/// Method that returns the root filesystem.
+type RootFn = Box<dyn Fn() -> Option<Vec<u8>>>;
+
+/// Method that enumerates UDFs.
+type UdfsFn = Box<dyn Fn(String) -> DataFusionResult<Vec<Arc<dyn ScalarUDFImpl>>>>;
+
+/// An evil.
+struct Evil {
+    /// Root file system.
+    root: RootFn,
+
+    /// Returns  UDFs.
+    udfs: UdfsFn,
+}
+
+impl Evil {
+    /// Get evil, multiplexed by env.
+    fn get() -> Self {
+        match std::env::var("EVIL").expect("evil specified").as_str() {
+            "root::many_files" => Self {
+                root: Box::new(root::many_files::root),
+                udfs: Box::new(root::many_files::udfs),
+            },
+            "runtime" => Self {
+                root: Box::new(runtime::root),
+                udfs: Box::new(runtime::udfs),
+            },
+            other => panic!("unknown evil: {other}"),
+        }
+    }
+}
+
+/// Return root file system.
+fn root() -> Option<Vec<u8>> {
+    (Evil::get().root)()
+}
+
+/// Returns our evil UDFs.
+fn udfs(source: String) -> DataFusionResult<Vec<Arc<dyn ScalarUDFImpl>>> {
+    (Evil::get().udfs)(source)
+}
+
+export! {
+    root_fs_tar: root,
+    scalar_udfs: udfs,
+}

--- a/guests/evil/src/root/many_files.rs
+++ b/guests/evil/src/root/many_files.rs
@@ -1,0 +1,31 @@
+//! Evil payloads that creates A LOT of files.
+use std::sync::Arc;
+
+use datafusion_common::Result as DataFusionResult;
+use datafusion_expr::ScalarUDFImpl;
+
+/// Return root file system.
+#[expect(clippy::unnecessary_wraps, reason = "public API through export! macro")]
+pub(crate) fn root() -> Option<Vec<u8>> {
+    let mut ar = tar::Builder::new(Vec::new());
+
+    const LIMIT: u64 = 10_000;
+    for i in 0..=LIMIT {
+        let mut header = tar::Header::new_gnu();
+        header.set_path(i.to_string()).unwrap();
+        header.set_size(0);
+        header.set_cksum();
+
+        ar.append(&header, b"".as_slice()).unwrap();
+    }
+
+    Some(ar.into_inner().unwrap())
+}
+
+/// Returns UDFs.
+///
+/// The passed `source` is ignored.
+#[expect(clippy::unnecessary_wraps, reason = "public API through export! macro")]
+pub(crate) fn udfs(_source: String) -> DataFusionResult<Vec<Arc<dyn ScalarUDFImpl>>> {
+    Ok(vec![])
+}

--- a/guests/evil/src/root/mod.rs
+++ b/guests/evil/src/root/mod.rs
@@ -1,0 +1,2 @@
+//! Evil things concerning the root file system.
+pub(crate) mod many_files;

--- a/guests/evil/src/runtime.rs
+++ b/guests/evil/src/runtime.rs
@@ -1,0 +1,145 @@
+//! Evil payloads that try to break the sandbox when the UDF is called.
+use std::sync::Arc;
+
+use arrow::datatypes::DataType;
+use datafusion_common::{Result as DataFusionResult, ScalarValue};
+use datafusion_expr::{ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility};
+
+/// UDF that executes a side effect.
+struct SideEffect {
+    /// Name.
+    name: &'static str,
+
+    /// Side effect.
+    effect: Box<dyn Fn() + Send + Sync>,
+
+    /// Signature of the UDF.
+    ///
+    /// We store this here because [`ScalarUDFImpl::signature`] requires us to return a reference.
+    signature: Signature,
+}
+
+impl SideEffect {
+    /// Create new side-effect UDF.
+    fn new<F>(name: &'static str, effect: F) -> Self
+    where
+        F: Fn() + Send + Sync + 'static,
+    {
+        Self {
+            name,
+            effect: Box::new(effect),
+            signature: Signature::uniform(0, vec![], Volatility::Immutable),
+        }
+    }
+}
+
+impl std::fmt::Debug for SideEffect {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self {
+            name,
+            effect: _,
+            signature,
+        } = self;
+
+        f.debug_struct("SideEffect")
+            .field("name", name)
+            .field("effect", &"<EFFECT>")
+            .field("signature", signature)
+            .finish()
+    }
+}
+
+impl ScalarUDFImpl for SideEffect {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        self.name
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> DataFusionResult<DataType> {
+        Ok(DataType::Null)
+    }
+
+    fn invoke_with_args(&self, _args: ScalarFunctionArgs) -> DataFusionResult<ColumnarValue> {
+        (self.effect)();
+
+        Ok(ColumnarValue::Scalar(ScalarValue::Null))
+    }
+}
+
+/// [Ackermann Function](https://en.wikipedia.org/wiki/Ackermann_function).
+///
+/// The Ackermann function is used here because it's not
+/// [primitive recursive](https://en.wikipedia.org/wiki/Primitive_recursive_function) and thus it cannot be optimized
+/// away into a for loop. Because the function is recursive and it won't be optimized away, a stack overflow can occur
+/// if `n` or `m` is large enough.
+fn ackermann(m: u128, n: u128) -> u128 {
+    if m == 0 {
+        n + 1
+    } else if n == 0 {
+        ackermann(m - 1, 1)
+    } else {
+        ackermann(m - 1, ackermann(m, n - 1))
+    }
+}
+
+/// Return root file system.
+///
+/// This always returns [`None`] because the example does not need any files.
+pub(crate) fn root() -> Option<Vec<u8>> {
+    None
+}
+
+/// Returns our evil UDFs.
+///
+/// The passed `source` is ignored.
+#[expect(clippy::unnecessary_wraps, reason = "public API through export! macro")]
+pub(crate) fn udfs(_source: String) -> DataFusionResult<Vec<Arc<dyn ScalarUDFImpl>>> {
+    Ok(vec![
+        Arc::new(SideEffect::new("fillstderr", || {
+            let s: String = std::iter::repeat_n('x', 10_000).collect();
+            for _ in 0..10_000 {
+                eprintln!("{s}");
+            }
+        })),
+        Arc::new(SideEffect::new("fillstdout", || {
+            let s: String = std::iter::repeat_n('x', 10_000).collect();
+            for _ in 0..10_000 {
+                println!("{s}");
+            }
+        })),
+        Arc::new(SideEffect::new("divzero", || {
+            #[allow(clippy::allow_attributes, unconditional_panic)]
+            let val = { 1u8 / 0 };
+
+            // simulate a side-effect via I/O so the compiler cannot optimize this method away
+            println!("{val}");
+        })),
+        Arc::new(SideEffect::new("maxptr", || {
+            let ptr = usize::MAX as *mut u8;
+
+            // SAFETY: not safe ;)
+            unsafe {
+                *ptr = 42;
+            }
+        })),
+        Arc::new(SideEffect::new("nullptr", || {
+            // SAFETY: not safe ;)
+            #[expect(deref_nullptr)]
+            unsafe {
+                *std::ptr::null_mut::<u8>() = 42;
+            }
+        })),
+        Arc::new(SideEffect::new("panic", || panic!("foo"))),
+        Arc::new(SideEffect::new("stackoverflow", || {
+            // simulate a side-effect via I/O so the compiler cannot optimize this method away
+            println!("{}", ackermann(10, 10));
+        })),
+    ])
+}

--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -24,10 +24,12 @@ wasmtime-wasi-io.workspace = true
 
 [dev-dependencies]
 datafusion-udf-wasm-bundle = { workspace = true, features = [
+  "evil",
   "example",
   "python"
 ] }
 insta.workspace = true
+regex.workspace = true
 tokio = { workspace = true, features = ["fs", "macros"] }
 wiremock = "0.6.5"
 

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -44,6 +44,8 @@ use datafusion_udf_wasm_bundle as _;
 #[cfg(test)]
 use insta as _;
 #[cfg(test)]
+use regex as _;
+#[cfg(test)]
 use wiremock as _;
 
 mod bindings;
@@ -200,7 +202,10 @@ impl WasmComponentPrecompiled {
             let engine = Engine::new(
                 wasmtime::Config::new()
                     .async_support(true)
-                    .memory_init_cow(true),
+                    .memory_init_cow(true)
+                    // Disable backtraces for now since debug info parsing doesn't seem to work and hence error
+                    // messages are nondeterministic.
+                    .wasm_backtrace(false),
             )
             .context("create WASM engine", None)?;
 

--- a/host/tests/integration_tests/evil/mod.rs
+++ b/host/tests/integration_tests/evil/mod.rs
@@ -1,0 +1,3 @@
+mod root;
+mod runtime;
+mod test_utils;

--- a/host/tests/integration_tests/evil/root.rs
+++ b/host/tests/integration_tests/evil/root.rs
@@ -1,0 +1,10 @@
+use crate::integration_tests::evil::test_utils::try_scalar_udfs;
+
+#[tokio::test]
+async fn test_many_files() {
+    let err = try_scalar_udfs("root::many_files").await.unwrap_err();
+
+    insta::assert_snapshot!(
+        err,
+        @"IO error: inodes limit reached: limit<=10000 current==10000 requested+=1");
+}

--- a/host/tests/integration_tests/evil/runtime.rs
+++ b/host/tests/integration_tests/evil/runtime.rs
@@ -1,0 +1,175 @@
+use std::sync::{Arc, LazyLock};
+
+use arrow::datatypes::{DataType, Field};
+use datafusion_common::{DataFusionError, config::ConfigOptions};
+use datafusion_expr::{ScalarFunctionArgs, ScalarUDFImpl, async_udf::AsyncScalarUDFImpl};
+use datafusion_udf_wasm_host::WasmScalarUdf;
+use regex::Regex;
+
+use crate::integration_tests::evil::test_utils::try_scalar_udfs;
+
+#[tokio::test]
+async fn test_fillstderr() {
+    let udf = udf("fillstderr").await;
+
+    insta::assert_snapshot!(
+        err_call_no_params(&udf).await,
+        @r"
+    call ScalarUdf::invoke_with_args
+
+    stderr:
+    xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+    caused by
+    External error: wasm trap: wasm `unreachable` instruction executed
+    ",
+    );
+}
+
+#[tokio::test]
+async fn test_fillstdout() {
+    let udf = udf("fillstdout").await;
+
+    // We do NOT store or print the stdout data (in contrast to stderr). Writes to stdout are discarded, so there is
+    // no limit. Hence, this payload never fails.
+    try_call_no_params(&udf).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_divzero() {
+    let udf = udf("divzero").await;
+
+    insta::assert_snapshot!(
+        normalize_panic_location(err_call_no_params(&udf).await),
+        @r"
+    call ScalarUdf::invoke_with_args
+
+    stderr:
+
+    thread '<unnamed>' (1) panicked at <FILE>:<LINE>:<ROW>:
+    attempt to divide by zero
+    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+    caused by
+    External error: wasm trap: wasm `unreachable` instruction executed
+    ",
+    );
+}
+
+#[tokio::test]
+async fn test_maxptr() {
+    let udf = udf("maxptr").await;
+    let err = err_call_no_params(&udf).await.to_string();
+
+    // linear memory size is nondeterministic
+    let err = Regex::new(r#"size 0x[0-9]+"#)
+        .unwrap()
+        .replace_all(&err, "size <SIZE>");
+
+    insta::assert_snapshot!(
+        err,
+        @r"
+    call ScalarUdf::invoke_with_args
+    caused by
+    External error: memory fault at wasm address 0xffffffff in linear memory of size <SIZE>
+    ",
+    );
+}
+
+#[tokio::test]
+async fn test_nullptr() {
+    let udf = udf("nullptr").await;
+
+    insta::assert_snapshot!(
+        normalize_panic_location(err_call_no_params(&udf).await),
+        @r"
+    call ScalarUdf::invoke_with_args
+
+    stderr:
+
+    thread '<unnamed>' (1) panicked at <FILE>:<LINE>:<ROW>:
+    null pointer dereference occurred
+    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+    thread caused non-unwinding panic. aborting.
+
+    caused by
+    External error: wasm trap: wasm `unreachable` instruction executed
+    ",
+    );
+}
+
+#[tokio::test]
+async fn test_panic() {
+    let udf = udf("panic").await;
+
+    insta::assert_snapshot!(
+        normalize_panic_location(err_call_no_params(&udf).await),
+        @r"
+    call ScalarUdf::invoke_with_args
+
+    stderr:
+
+    thread '<unnamed>' (1) panicked at <FILE>:<LINE>:<ROW>:
+    foo
+    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+    caused by
+    External error: wasm trap: wasm `unreachable` instruction executed
+    ",
+    );
+}
+
+#[tokio::test]
+async fn test_stackoverflow() {
+    let udf = udf("stackoverflow").await;
+
+    insta::assert_snapshot!(
+        err_call_no_params(&udf).await,
+        @r"
+    call ScalarUdf::invoke_with_args
+    caused by
+    External error: wasm trap: call stack exhausted
+    ",
+    );
+}
+
+/// Get evil UDF.
+async fn udf(name: &'static str) -> WasmScalarUdf {
+    try_scalar_udfs("runtime")
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|udf| udf.name() == name)
+        .unwrap()
+}
+
+async fn try_call_no_params(udf: &WasmScalarUdf) -> Result<(), DataFusionError> {
+    udf.invoke_async_with_args(
+        ScalarFunctionArgs {
+            args: vec![],
+            arg_fields: vec![],
+            number_rows: 1,
+            return_field: Arc::new(Field::new("r", DataType::Null, true)),
+        },
+        &ConfigOptions::default(),
+    )
+    .await
+    .map(|_| ())
+}
+
+async fn err_call_no_params(udf: &WasmScalarUdf) -> DataFusionError {
+    try_call_no_params(udf).await.unwrap_err()
+}
+
+/// Normalize line & column numbers in panic message, so that changing the code in the respective file does not change
+/// the expected outcome. This makes it easier to add new test cases or update the code without needing to update all
+/// results.
+fn normalize_panic_location(e: impl ToString) -> String {
+    let e = e.to_string();
+
+    static REGEX: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r#"(?<m>panicked at) [^:]+:[0-9]+:[0-9]+:"#).unwrap());
+
+    REGEX
+        .replace_all(&e, r#"$m <FILE>:<LINE>:<ROW>:"#)
+        .to_string()
+}

--- a/host/tests/integration_tests/evil/test_utils.rs
+++ b/host/tests/integration_tests/evil/test_utils.rs
@@ -1,0 +1,28 @@
+use datafusion_common::DataFusionError;
+use datafusion_udf_wasm_host::{WasmComponentPrecompiled, WasmPermissions, WasmScalarUdf};
+use tokio::{runtime::Handle, sync::OnceCell};
+
+/// Static precompiled WASM component for tests
+static COMPONENT: OnceCell<WasmComponentPrecompiled> = OnceCell::const_new();
+
+/// Returns a static reference to the precompiled WASM component.
+async fn component() -> &'static WasmComponentPrecompiled {
+    COMPONENT
+        .get_or_init(async || {
+            WasmComponentPrecompiled::new(datafusion_udf_wasm_bundle::BIN_EVIL.into())
+                .await
+                .unwrap()
+        })
+        .await
+}
+
+/// Try to get scalar UDFs.
+pub(crate) async fn try_scalar_udfs(
+    evil: &'static str,
+) -> Result<Vec<WasmScalarUdf>, DataFusionError> {
+    let component = component().await;
+
+    let permissions = WasmPermissions::new().with_env("EVIL".to_owned(), evil.to_owned());
+
+    WasmScalarUdf::new(component, &permissions, Handle::current(), "".to_owned()).await
+}

--- a/host/tests/integration_tests/mod.rs
+++ b/host/tests/integration_tests/mod.rs
@@ -1,2 +1,3 @@
+mod evil;
 mod python;
 mod rust;


### PR DESCRIPTION
Add the overall infrastructure so we can implement a large zoo of evil test payloads. Adds a few payloads already to demonstrate the architecture.

This somewhat streamlines/re-designs the `guests/bundle` build script.

For #16.
