### PR TITLE
refactor: streamline guest bundling

### DIFF
--- a/guests/bundle/src/lib.rs
+++ b/guests/bundle/src/lib.rs
@@ -1,9 +1,3 @@
 //! Bundles guests as pre-compiled WASM bytecode.
 
-/// "add-one" example.
-#[cfg(feature = "example")]
-pub static BIN_EXAMPLE: &[u8] = include_bytes!(env!("BIN_PATH_EXAMPLE"));
-
-/// Python UDF.
-#[cfg(feature = "python")]
-pub static BIN_PYTHON: &[u8] = include_bytes!(env!("BIN_PATH_PYTHON"));
+include!(concat!(env!("OUT_DIR"), "/gen.rs"));

--- a/guests/python/Justfile
+++ b/guests/python/Justfile
@@ -163,13 +163,13 @@ build-lib profile: download-python-sdk download-wasi-sdk python-site-packages
 do profile: (build-lib profile)
 
 # create dev/debug build
-debug: (do "debug")
+build-debug: (do "debug")
 
 # create release build
-release: (do "release")
+build-release: (do "release")
 
 # checks build
-check-build: debug
+check-build: build-debug
 
 # clean build artifacts
 clean:

--- a/guests/python/README.md
+++ b/guests/python/README.md
@@ -4,13 +4,13 @@
 Use:
 
 ```console
-just debug
+just build-debug
 ```
 
 or
 
 ```console
-just release
+just build-release
 ```
 
 ## Python Version


### PR DESCRIPTION
- auto-generate the content of `lib.rs` within the build script
- allow a single feature flag with multiple binaries (e.g. for examples)
- derive just command and output file from `lib` or `example`

Extracted from #162.