### PR TITLE
refactor: reduce dependencies of `query` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1370,6 +1370,7 @@ version = "0.1.0"
 dependencies = [
  "datafusion",
  "datafusion-common",
+ "datafusion-execution",
  "datafusion-expr",
  "datafusion-sql",
  "datafusion-udf-wasm-bundle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ arrow = { version = "56.2.0", default-features = false, features = ["ipc"] }
 chrono = { version = "0.4.42", default-features = false }
 datafusion = { version = "50.3.0", default-features = false }
 datafusion-common = { version = "50.3.0", default-features = false }
+datafusion-execution = { version = "50.3.0", default-features = false }
 datafusion-expr = { version = "50.3.0", default-features = false }
 datafusion-sql = { version = "50.3.0", default-features = false }
 datafusion-udf-wasm-arrow2bytes = { path = "arrow2bytes", version = "0.1.0" }

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -5,8 +5,8 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-datafusion.workspace = true
 datafusion-common.workspace = true
+datafusion-execution.workspace = true
 datafusion-expr.workspace = true
 datafusion-sql.workspace = true
 datafusion-udf-wasm-host.workspace = true
@@ -14,6 +14,7 @@ sqlparser.workspace = true
 tokio.workspace = true
 
 [dev-dependencies]
+datafusion.workspace = true
 datafusion-udf-wasm-bundle = { workspace = true, features = ["python"] }
 datafusion-udf-wasm-host = { workspace = true }
 insta.workspace = true

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -4,8 +4,8 @@
 use std::collections::HashMap;
 use std::pin::Pin;
 
-use datafusion::execution::TaskContext;
 use datafusion_common::{DataFusionError, Result as DataFusionResult};
+use datafusion_execution::TaskContext;
 use datafusion_sql::parser::{DFParserBuilder, Statement};
 use sqlparser::ast::{CreateFunctionBody, Expr, Statement as SqlStatement, Value};
 use sqlparser::dialect::dialect_from_str;

--- a/query/tests/integration.rs
+++ b/query/tests/integration.rs
@@ -7,11 +7,10 @@
 
 use std::collections::HashMap;
 
-use datafusion::{
-    assert_batches_eq,
-    prelude::{DataFrame, SessionContext},
+use datafusion::prelude::{DataFrame, SessionContext};
+use datafusion_common::{
+    Result as DataFusionResult, assert_batches_eq, test_util::batches_to_string,
 };
-use datafusion_common::{Result as DataFusionResult, test_util::batches_to_string};
 use datafusion_udf_wasm_host::WasmPermissions;
 use datafusion_udf_wasm_query::{
     ComponentFn, Lang, ParsedQuery, UdfQueryParser,


### PR DESCRIPTION
While we need the full `datafusion` department for testing, we only need `datafusion-execution` for the actual compilation of the `query` crate. This somewhat speeds up the compilation of downstream consumers like InfluxDB since they don't need to wait for `datafusion` to be compiled before they can compile `query` (that's automatically handled by cargo).
