### PR TITLE
ci: free up disk space

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,34 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
+      - name: Free disk space
+        run: |
+          df -h
+
+          to_delete=(
+            "/lib/firefox"
+            "/lib/google-cloud-sdk"
+            "/lib/jvm"
+            "/lib/llvm-16"
+            "/lib/llvm-17"
+            "/opt/az"
+            "/opt/google"
+            "/opt/hostedtoolcache/CodeQL"
+            "/opt/hostedtoolcache/PyPy"
+            "/opt/hostedtoolcache/Ruby"
+            "/opt/hostedtoolcache/go"
+            "/opt/hostedtoolcache/node"
+            "/opt/microsoft"
+            "/opt/pipx"
+            "/usr/share/swift"
+          )
+          for d in "${to_delete[@]}"; do
+            echo "delete $d"
+            sudo rm -rf "$d"
+          done
+
+          df -h
+
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:


### PR DESCRIPTION
This should prevent some `no space left on device` errors. Originally we've fixed that in #124 but I hit this issue again in #175, so we're back with a slightly bigger hammer:

Turns out that the CI image -- which is supplied by GitHub (see https://github.com/actions/runner-images ) -- is just mounted read-write and is included in the disk space usage. The working directly is NOT mounted under a separate mount point (which is TBH a somewhat bizarre choice). Over time GitHub included all kinds of mess into the CI images and the bigger the bloat, the smaller is the headroom that we have to actual do useful stuff. So we de-bloat the image a bit by removing a few things. Sadly we cannot just use a custom image without a custom runner :roll_eyes: 