### PR TITLE
feat: disallow compressed IPC data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,6 +191,7 @@ dependencies = [
  "arrow-select",
  "flatbuffers",
  "lz4_flex",
+ "zstd",
 ]
 
 [[package]]
@@ -449,6 +450,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd405d82c84ff7f35739f175f67d8b9fb7687a0e84ccdc78bd3568839827cf07"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -2039,6 +2042,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2434,6 +2447,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "portable-atomic"
@@ -4264,4 +4283,32 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/arrow2bytes/Cargo.toml
+++ b/arrow2bytes/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 arrow.workspace = true
 
 [dev-dependencies]
+arrow = { workspace = true, features = ["ipc_compression"] }
 insta.workspace = true
 
 [lints]

--- a/arrow2bytes/src/compression_check.rs
+++ b/arrow2bytes/src/compression_check.rs
@@ -1,0 +1,115 @@
+//! Scan IPC data for compressed data.
+//!
+//! This is a workaround until <https://github.com/apache/arrow-rs/issues/8917> is implemented.
+
+use std::io::{Cursor, Read, Seek};
+
+use arrow::{
+    error::ArrowError,
+    ipc::{BodyCompression, MessageHeader, root_as_message},
+};
+
+/// Detect and fail if there's compressed data.
+pub(crate) fn detect_compressed_data(bytes: &[u8]) -> Result<(), ArrowError> {
+    let mut reader = Cursor::new(bytes);
+
+    loop {
+        let Some(meta_len) = read_meta_len(&mut reader)? else {
+            break;
+        };
+        let mut meta = vec![0; meta_len];
+        reader.read_exact(&mut meta)?;
+        let msg = root_as_message(&meta).map_err(|err| {
+            ArrowError::ParseError(format!("Unable to get root as message: {err:?}"))
+        })?;
+
+        match msg.header_type() {
+            MessageHeader::Schema => {
+                // never compressed
+            }
+            MessageHeader::DictionaryBatch => {
+                if let Some(batch) = msg.header_as_dictionary_batch()
+                    && let Some(batch) = batch.data()
+                    && let Some(compression) = batch.compression()
+                {
+                    return Err(compression_err("dictionary batch", compression));
+                }
+            }
+            MessageHeader::RecordBatch => {
+                if let Some(batch) = msg.header_as_record_batch()
+                    && let Some(compression) = batch.compression()
+                {
+                    return Err(compression_err("record batch", compression));
+                }
+            }
+            x => {
+                return Err(ArrowError::ParseError(format!(
+                    "Unsupported message header type in IPC stream: '{x:?}'"
+                )));
+            }
+        }
+
+        let body_len = msg.bodyLength();
+        if body_len < 0 {
+            return Err(ArrowError::ParseError(format!(
+                "Invalid body length: {body_len}"
+            )));
+        }
+        reader.seek_relative(body_len)?;
+    }
+
+    Ok(())
+}
+
+/// Read the metadata length for the next message from the underlying stream.
+///
+/// # Returns
+/// - `Ok(None)` if the reader signals the end of stream with EOF on
+///   the first read
+/// - `Err(_)` if the reader returns an error other than EOF on the first
+///   read, or if the metadata length is less than 0.
+/// - `Ok(Some(_))` with the length otherwise.
+fn read_meta_len(reader: &mut Cursor<&[u8]>) -> Result<Option<usize>, ArrowError> {
+    const CONTINUATION_MARKER: [u8; 4] = [0xff; 4];
+    let mut meta_len: [u8; 4] = [0; 4];
+    match reader.read_exact(&mut meta_len) {
+        Ok(_) => {}
+        Err(e) => {
+            return if e.kind() == std::io::ErrorKind::UnexpectedEof {
+                // Handle EOF without the "0xFFFFFFFF 0x00000000"
+                // valid according to:
+                // https://arrow.apache.org/docs/format/Columnar.html#ipc-streaming-format
+                Ok(None)
+            } else {
+                Err(ArrowError::from(e))
+            };
+        }
+    }
+
+    let meta_len = {
+        // If a continuation marker is encountered, skip over it and read
+        // the size from the next four bytes.
+        if meta_len == CONTINUATION_MARKER {
+            reader.read_exact(&mut meta_len)?;
+        }
+
+        i32::from_le_bytes(meta_len)
+    };
+
+    if meta_len == 0 {
+        return Ok(None);
+    }
+
+    let meta_len = usize::try_from(meta_len)
+        .map_err(|_| ArrowError::ParseError(format!("Invalid metadata length: {meta_len}")))?;
+
+    Ok(Some(meta_len))
+}
+
+/// Generate error for encountered compression.
+fn compression_err(what: &'static str, compression: BodyCompression<'_>) -> ArrowError {
+    ArrowError::IpcError(format!(
+        "IPC {what} is compressed using {}, but compressed data MUST NOT cross the security boundary. If you want to handle compressed data, please decompress it within the guest.",
+        compression.codec().variant_name().unwrap_or("<unknown>")
+    ))
+}

--- a/arrow2bytes/src/lib.rs
+++ b/arrow2bytes/src/lib.rs
@@ -22,6 +22,8 @@ use arrow::{
 #[cfg(test)]
 use insta as _;
 
+mod compression_check;
+
 /// Convert an [`Array`] to bytes.
 ///
 /// This is done by encoding writing this as a [`RecordBatch`] with a single [`Field`].
@@ -48,6 +50,8 @@ pub fn array2bytes(array: ArrayRef) -> Vec<u8> {
 ///
 /// See [`array2bytes`] for the reverse method and the format description.
 pub fn bytes2array(bytes: &[u8]) -> Result<ArrayRef, ArrowError> {
+    compression_check::detect_compressed_data(bytes)?;
+
     let cursor = Cursor::new(bytes);
     let mut reader = StreamReader::try_new(cursor, None)?;
     let Some(res) = reader.next() else {

--- a/arrow2bytes/tests/array.rs
+++ b/arrow2bytes/tests/array.rs
@@ -8,20 +8,18 @@ use arrow::{
         ArrayRef, Int64Array, ListArray, RecordBatch, RecordBatchOptions, StringDictionaryBuilder,
     },
     datatypes::{DataType, Field, Int32Type, Schema},
-    ipc::writer::StreamWriter,
+    error::ArrowError,
+    ipc::{
+        CompressionType,
+        writer::{IpcWriteOptions, StreamWriter},
+    },
 };
 use datafusion_udf_wasm_arrow2bytes::{array2bytes, bytes2array};
 
 #[test]
 fn test_roundtrip() {
-    roundtrip(Arc::new(Int64Array::from_iter([Some(1), None, Some(3)])));
-
-    let mut builder = StringDictionaryBuilder::<Int32Type>::new();
-    builder.append("foo").unwrap();
-    builder.append_null();
-    builder.append("bar").unwrap();
-    builder.append("foo").unwrap();
-    roundtrip(Arc::new(builder.finish()));
+    roundtrip(int64_array());
+    roundtrip(string_dict_array());
 }
 
 #[test]
@@ -89,14 +87,8 @@ fn test_err_multiple_columns() {
         Field::new("a", DataType::Int64, true),
         Field::new("b", DataType::Int64, true),
     ]));
-    let batch = RecordBatch::try_new(
-        Arc::clone(&schema),
-        vec![
-            Arc::new(Int64Array::new_null(0)),
-            Arc::new(Int64Array::new_null(0)),
-        ],
-    )
-    .unwrap();
+    let batch =
+        RecordBatch::try_new(Arc::clone(&schema), vec![int64_array(), int64_array()]).unwrap();
     let mut writer =
         StreamWriter::try_new(Vec::new(), &schema).expect("writing to buffer never fails");
     writer.write(&batch).unwrap();
@@ -136,9 +128,66 @@ fn test_deeply_nested() {
     );
 }
 
+#[test]
+fn test_err_compression() {
+    insta::assert_snapshot!(
+        compression_err(int64_array(), CompressionType::LZ4_FRAME),
+        @"Ipc error: IPC record batch is compressed using LZ4_FRAME, but compressed data MUST NOT cross the security boundary. If you want to handle compressed data, please decompress it within the guest.",
+    );
+    insta::assert_snapshot!(
+        compression_err(int64_array(), CompressionType::ZSTD),
+        @"Ipc error: IPC record batch is compressed using ZSTD, but compressed data MUST NOT cross the security boundary. If you want to handle compressed data, please decompress it within the guest.",
+    );
+    insta::assert_snapshot!(
+        compression_err(string_dict_array(), CompressionType::LZ4_FRAME),
+        @"Ipc error: IPC dictionary batch is compressed using LZ4_FRAME, but compressed data MUST NOT cross the security boundary. If you want to handle compressed data, please decompress it within the guest.",
+    );
+    insta::assert_snapshot!(
+        compression_err(string_dict_array(), CompressionType::ZSTD),
+        @"Ipc error: IPC dictionary batch is compressed using ZSTD, but compressed data MUST NOT cross the security boundary. If you want to handle compressed data, please decompress it within the guest.",
+    );
+}
+
 #[track_caller]
 fn roundtrip(array: ArrayRef) {
     let bytes = array2bytes(Arc::clone(&array));
     let array2 = bytes2array(&bytes).unwrap();
     assert_eq!(&array, &array2);
+}
+
+/// Create a non-empty int64 array.
+fn int64_array() -> ArrayRef {
+    Arc::new(Int64Array::from_iter([Some(1), None, Some(3)]))
+}
+
+/// Create a non-empty dict-encoded string array.
+fn string_dict_array() -> ArrayRef {
+    let mut builder = StringDictionaryBuilder::<Int32Type>::new();
+    builder.append("foo").unwrap();
+    builder.append_null();
+    builder.append("bar").unwrap();
+    builder.append("foo").unwrap();
+    Arc::new(builder.finish())
+}
+
+#[track_caller]
+fn compression_err(array: ArrayRef, compression: CompressionType) -> ArrowError {
+    let schema = Arc::new(Schema::new(vec![Field::new(
+        "a",
+        array.data_type().clone(),
+        true,
+    )]));
+    let batch = RecordBatch::try_new(Arc::clone(&schema), vec![array]).unwrap();
+    let mut writer = StreamWriter::try_new_with_options(
+        Vec::new(),
+        &schema,
+        IpcWriteOptions::default()
+            .try_with_compression(Some(compression))
+            .unwrap(),
+    )
+    .expect("writing to buffer never fails");
+    writer.write(&batch).unwrap();
+    let bytes = writer.into_inner().unwrap();
+
+    bytes2array(&bytes).unwrap_err()
 }


### PR DESCRIPTION
- avoids ZIP bombs, i.e. data that consumes A LOT of memory on the host
- avoids CPU-based denial-of-service attacks
- assuming that arrays within the guest require the same amount of bytes than within the host is helpful, since it means that memory consumption stays somewhat in check
