### PR TITLE
chore: remove unused cargo-deny GitHub orgs

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -54,8 +54,3 @@ deny = [
 unknown-git = "deny"
 required-git-spec = "rev"
 unused-allowed-source = "deny"
-
-[sources.allow-org]
-github = [
-  "influxdata",
-]


### PR DESCRIPTION
We've removed the usage of our DataFusion fork in #175.
