### PR TITLE
chore: move `cranelift-*` to `wasmtime` dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,13 +23,14 @@ updates:
           - "sqlparser"
       wasmtime:
         patterns:
+          - "cranelift-*"
+          - "pulley-*"
           - "wasmtime"
           - "wasmtime-*"
       # Catch-all group to bundle version updates (but not security updates) everything
       # else into a single PR.
       rust-other:
         patterns:
-          - "*"
           - "*"
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
See #212, which should probably have been included in #211.