### PR TITLE
feat: check DataType-related conversion

### DIFF
--- a/guests/evil/src/complex/many_inputs.rs
+++ b/guests/evil/src/complex/many_inputs.rs
@@ -1,0 +1,61 @@
+//! UDF with many inputs.
+
+use std::sync::Arc;
+
+use arrow::datatypes::DataType;
+use datafusion_common::{DataFusionError, Result as DataFusionResult};
+use datafusion_expr::{ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility};
+
+/// UDF with specific signature.
+#[derive(Debug, PartialEq, Eq, Hash)]
+struct SignatureUDF {
+    /// Name.
+    name: &'static str,
+
+    /// The signature.
+    signature: Signature,
+}
+
+impl SignatureUDF {
+    /// Create new UDF.
+    fn new(name: &'static str, signature: Signature) -> Self {
+        Self { name, signature }
+    }
+}
+
+impl ScalarUDFImpl for SignatureUDF {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        self.name
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> DataFusionResult<DataType> {
+        Ok(DataType::Null)
+    }
+
+    fn invoke_with_args(&self, _args: ScalarFunctionArgs) -> DataFusionResult<ColumnarValue> {
+        Err(DataFusionError::NotImplemented(
+            "invoke_with_args".to_owned(),
+        ))
+    }
+}
+
+/// Returns our evil UDFs.
+///
+/// The passed `source` is ignored.
+#[expect(clippy::unnecessary_wraps, reason = "public API through export! macro")]
+pub(crate) fn udfs(_source: String) -> DataFusionResult<Vec<Arc<dyn ScalarUDFImpl>>> {
+    let limit: usize = std::env::var("limit").unwrap().parse().unwrap();
+
+    Ok(vec![Arc::new(SignatureUDF::new(
+        "input_count",
+        Signature::exact(vec![DataType::Null; limit + 1], Volatility::Immutable),
+    ))])
+}

--- a/guests/evil/src/complex/mod.rs
+++ b/guests/evil/src/complex/mod.rs
@@ -7,6 +7,9 @@ use datafusion_expr::{
 };
 
 pub(crate) mod error;
+pub(crate) mod many_inputs;
+pub(crate) mod return_type;
+pub(crate) mod return_value;
 pub(crate) mod udf_long_name;
 pub(crate) mod udfs_duplicate_names;
 pub(crate) mod udfs_many;

--- a/guests/evil/src/complex/return_type.rs
+++ b/guests/evil/src/complex/return_type.rs
@@ -1,0 +1,117 @@
+//! Badness related to return data types.
+
+use std::{collections::HashMap, sync::Arc};
+
+use arrow::datatypes::{DataType, Field};
+use datafusion_common::{DataFusionError, Result as DataFusionResult};
+use datafusion_expr::{
+    ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, TypeSignature, Volatility,
+};
+
+/// UDF that returns a specific data type.
+#[derive(Debug, PartialEq, Eq, Hash)]
+struct ReturnTypeUDF {
+    /// Name.
+    name: &'static str,
+
+    /// The return type
+    return_type: DataType,
+}
+
+impl ReturnTypeUDF {
+    /// Create new UDF.
+    fn new(name: &'static str, return_type: DataType) -> Self {
+        Self { name, return_type }
+    }
+}
+
+impl ScalarUDFImpl for ReturnTypeUDF {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        self.name
+    }
+
+    fn signature(&self) -> &Signature {
+        static S: Signature = Signature {
+            type_signature: TypeSignature::Uniform(0, vec![]),
+            volatility: Volatility::Immutable,
+        };
+
+        &S
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> DataFusionResult<DataType> {
+        Ok(self.return_type.clone())
+    }
+
+    fn invoke_with_args(&self, _args: ScalarFunctionArgs) -> DataFusionResult<ColumnarValue> {
+        Err(DataFusionError::NotImplemented(
+            "invoke_with_args".to_owned(),
+        ))
+    }
+}
+
+/// Returns our evil UDFs.
+///
+/// The passed `source` is ignored.
+#[expect(clippy::unnecessary_wraps, reason = "public API through export! macro")]
+pub(crate) fn udfs(_source: String) -> DataFusionResult<Vec<Arc<dyn ScalarUDFImpl>>> {
+    let max_identifier_length: usize = std::env::var("max_identifier_length")
+        .unwrap()
+        .parse()
+        .unwrap();
+    let max_aux_string_length: usize = std::env::var("max_aux_string_length")
+        .unwrap()
+        .parse()
+        .unwrap();
+    let max_depth: usize = std::env::var("max_depth").unwrap().parse().unwrap();
+    let max_complexity: usize = std::env::var("max_complexity").unwrap().parse().unwrap();
+
+    Ok(vec![
+        Arc::new(ReturnTypeUDF::new(
+            "dt_depth",
+            (0..=max_depth).fold(DataType::Int64, |dt, _| {
+                DataType::List(Arc::new(Field::new("f", dt, true)))
+            }),
+        )),
+        Arc::new(ReturnTypeUDF::new(
+            "field_name",
+            DataType::List(Arc::new(Field::new(
+                std::iter::repeat_n('x', max_identifier_length + 1).collect::<String>(),
+                DataType::Int64,
+                true,
+            ))),
+        )),
+        Arc::new(ReturnTypeUDF::new(
+            "field_md_key",
+            DataType::List(Arc::new(
+                Field::new("f", DataType::Int64, true).with_metadata(HashMap::from([(
+                    std::iter::repeat_n('x', max_identifier_length + 1).collect::<String>(),
+                    "value".to_owned(),
+                )])),
+            )),
+        )),
+        Arc::new(ReturnTypeUDF::new(
+            "field_md_value",
+            DataType::List(Arc::new(
+                Field::new("f", DataType::Int64, true).with_metadata(HashMap::from([(
+                    "key".to_owned(),
+                    std::iter::repeat_n('x', max_aux_string_length + 1).collect::<String>(),
+                )])),
+            )),
+        )),
+        Arc::new(ReturnTypeUDF::new(
+            "field_md_items",
+            DataType::List(Arc::new(
+                Field::new("f", DataType::Int64, true).with_metadata(
+                    (0..=max_complexity)
+                        .map(|idx| (idx.to_string(), "value".to_owned()))
+                        .collect(),
+                ),
+            )),
+        )),
+    ])
+}

--- a/guests/evil/src/complex/return_value.rs
+++ b/guests/evil/src/complex/return_value.rs
@@ -1,0 +1,93 @@
+//! Payloads that return complex values when being invoked.
+
+use std::sync::Arc;
+
+use arrow::{
+    array::{Int64Array, StructArray},
+    datatypes::{DataType, Field},
+};
+use datafusion_common::{DataFusionError, Result as DataFusionResult, ScalarValue};
+use datafusion_expr::{
+    ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, TypeSignature, Volatility,
+};
+
+use crate::common::DynBox;
+
+/// UDF that returns a specific data type.
+#[derive(Debug, PartialEq, Eq, Hash)]
+struct ReturnValueUDF {
+    /// Name.
+    name: &'static str,
+
+    /// The return value
+    return_value: DynBox<ColumnarValue>,
+}
+
+impl ReturnValueUDF {
+    /// Create new UDF.
+    fn new(name: &'static str, return_value: ColumnarValue) -> Self {
+        Self {
+            name,
+            return_value: DynBox(Box::new(return_value)),
+        }
+    }
+}
+
+impl ScalarUDFImpl for ReturnValueUDF {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        self.name
+    }
+
+    fn signature(&self) -> &Signature {
+        static S: Signature = Signature {
+            type_signature: TypeSignature::Uniform(0, vec![]),
+            volatility: Volatility::Immutable,
+        };
+
+        &S
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> DataFusionResult<DataType> {
+        Err(DataFusionError::NotImplemented("return_type".to_owned()))
+    }
+
+    fn invoke_with_args(&self, _args: ScalarFunctionArgs) -> DataFusionResult<ColumnarValue> {
+        Ok(self.return_value.clone())
+    }
+}
+
+/// Returns our evil UDFs.
+///
+/// The passed `source` is ignored.
+#[expect(clippy::unnecessary_wraps, reason = "public API through export! macro")]
+pub(crate) fn udfs(_source: String) -> DataFusionResult<Vec<Arc<dyn ScalarUDFImpl>>> {
+    let max_depth: usize = std::env::var("max_depth").unwrap().parse().unwrap();
+
+    Ok(vec![
+        Arc::new(ReturnValueUDF::new(
+            "dt_depth_array",
+            ColumnarValue::Array((0..=max_depth).fold(
+                Arc::new(Int64Array::new(vec![1].into(), None)),
+                |a, _| {
+                    Arc::new(StructArray::from(vec![(
+                        Arc::new(Field::new("a", a.data_type().clone(), true)),
+                        a,
+                    )]))
+                },
+            )),
+        )),
+        Arc::new(ReturnValueUDF::new(
+            "dt_depth_scalar",
+            ColumnarValue::Scalar((0..=max_depth).fold(ScalarValue::Int64(Some(1)), |v, _| {
+                ScalarValue::Struct(Arc::new(StructArray::from(vec![(
+                    Arc::new(Field::new("a", v.data_type(), true)),
+                    v.to_array().unwrap(),
+                )])))
+            })),
+        )),
+    ])
+}

--- a/guests/evil/src/lib.rs
+++ b/guests/evil/src/lib.rs
@@ -40,6 +40,18 @@ impl Evil {
                 root: Box::new(common::root_empty),
                 udfs: Box::new(complex::error::udfs),
             },
+            "complex::many_inputs" => Self {
+                root: Box::new(common::root_empty),
+                udfs: Box::new(complex::many_inputs::udfs),
+            },
+            "complex::return_type" => Self {
+                root: Box::new(common::root_empty),
+                udfs: Box::new(complex::return_type::udfs),
+            },
+            "complex::return_value" => Self {
+                root: Box::new(common::root_empty),
+                udfs: Box::new(complex::return_value::udfs),
+            },
             "complex::udf_long_name" => Self {
                 root: Box::new(common::root_empty),
                 udfs: Box::new(complex::udf_long_name::udfs),

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -620,7 +620,8 @@ impl WasmScalarUdf {
                     Some(&store_guard.data().stderr.contents()),
                 )?;
             ComplexityToken::new(permissions.trusted_data_limits.clone())?
-                .check_identifier(&name)?;
+                .check_identifier(&name)
+                .context("UDF name")?;
             if !names_seen.insert(name.clone()) {
                 return Err(DataFusionError::External(
                     format!("non-unique UDF name: '{name}'").into(),

--- a/host/tests/integration_tests/evil/complex.rs
+++ b/host/tests/integration_tests/evil/complex.rs
@@ -58,6 +58,183 @@ async fn test_err_nested_ctx() {
 }
 
 #[tokio::test]
+async fn test_many_inputs() {
+    let err = try_scalar_udfs_with_env(
+        "complex::many_inputs",
+        &[(
+            "limit",
+            &TrustedDataLimits::default().max_complexity.to_string(),
+        )],
+    )
+    .await
+    .unwrap_err();
+
+    insta::assert_snapshot!(
+        err,
+        @r"
+    type signature
+    caused by
+    exact signature
+    caused by
+    child 48
+    caused by
+    Resources exhausted: data structure complexity: limit=100
+    ");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_return_type_dt_depth() {
+    let err = run_return_type_udf("dt_depth").await;
+
+    insta::assert_snapshot!(
+        err,
+        @r"
+    field
+    caused by
+    field data type
+    caused by
+    field
+    caused by
+    field data type
+    caused by
+    field
+    caused by
+    field data type
+    caused by
+    field
+    caused by
+    field data type
+    caused by
+    Resources exhausted: data structure depth: limit=10
+    ",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_return_type_field_name() {
+    let err = run_return_type_udf("field_name").await;
+
+    insta::assert_snapshot!(
+        err,
+        @r"
+    field
+    caused by
+    field name
+    caused by
+    Resources exhausted: identifier length: got=51, limit=50
+    ",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_return_type_field_md_key() {
+    let err = run_return_type_udf("field_md_key").await;
+
+    insta::assert_snapshot!(
+        err,
+        @r"
+    field
+    caused by
+    field metadata
+    caused by
+    metadata key
+    caused by
+    Resources exhausted: identifier length: got=51, limit=50
+    ",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_return_type_field_md_value() {
+    let err = run_return_type_udf("field_md_value").await;
+
+    insta::assert_snapshot!(
+        err,
+        @r"
+    field
+    caused by
+    field metadata
+    caused by
+    metadata value
+    caused by
+    Resources exhausted: auxiliary string length: got=10001, limit=10000
+    ",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_return_type_field_md_items() {
+    let err = run_return_type_udf("field_md_items").await;
+
+    insta::assert_snapshot!(
+        err,
+        @r"
+    field
+    caused by
+    field metadata
+    caused by
+    Resources exhausted: data structure complexity: limit=100
+    ",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_return_value_dt_depth_array() {
+    let err = run_return_value_udf("dt_depth_array").await;
+
+    insta::assert_snapshot!(
+        err,
+        @r"
+    array
+    caused by
+    field 0
+    caused by
+    field data type
+    caused by
+    field 0
+    caused by
+    field data type
+    caused by
+    field 0
+    caused by
+    field data type
+    caused by
+    field 0
+    caused by
+    Resources exhausted: data structure depth: limit=10
+    ",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_return_value_dt_depth_scalar() {
+    let err = run_return_value_udf("dt_depth_scalar").await;
+
+    insta::assert_snapshot!(
+        err,
+        @r"
+    scalar
+    caused by
+    array
+    caused by
+    field 0
+    caused by
+    field data type
+    caused by
+    field 0
+    caused by
+    field data type
+    caused by
+    field 0
+    caused by
+    field data type
+    caused by
+    Resources exhausted: data structure depth: limit=10
+    ",
+    );
+}
+
+#[tokio::test]
 async fn test_udf_long_name() {
     let err = try_scalar_udfs_with_env(
         "complex::udf_long_name",
@@ -73,7 +250,11 @@ async fn test_udf_long_name() {
 
     insta::assert_snapshot!(
         err,
-        @"Resources exhausted: identifier length: got=51, limit=50");
+        @r"
+    UDF name
+    caused by
+    Resources exhausted: identifier length: got=51, limit=50
+    ");
 }
 
 #[tokio::test]
@@ -109,6 +290,68 @@ async fn run_err_udf(name: &'static str, limit: usize) -> DataFusionError {
         .into_iter()
         .find(|udf| udf.name() == name)
         .unwrap();
+
+    udf.invoke_async_with_args(ScalarFunctionArgs {
+        args: vec![],
+        arg_fields: vec![],
+        number_rows: 1,
+        return_field: Arc::new(Field::new("r", DataType::Null, true)),
+        config_options: Arc::new(ConfigOptions::default()),
+    })
+    .await
+    .unwrap_err()
+}
+
+/// Test UDF related to return type information.
+async fn run_return_type_udf(name: &'static str) -> DataFusionError {
+    let TrustedDataLimits {
+        max_identifier_length,
+        max_aux_string_length,
+        max_depth,
+        max_complexity,
+    } = TrustedDataLimits::default();
+
+    let udf = try_scalar_udfs_with_env(
+        "complex::return_type",
+        &[
+            ("max_identifier_length", &max_identifier_length.to_string()),
+            ("max_aux_string_length", &max_aux_string_length.to_string()),
+            ("max_depth", &max_depth.to_string()),
+            ("max_complexity", &max_complexity.to_string()),
+        ],
+    )
+    .await
+    .unwrap()
+    .into_iter()
+    .find(|udf| udf.name() == name)
+    .unwrap();
+
+    udf.return_type(&[]).unwrap_err()
+}
+
+/// Test UDF related to return values.
+async fn run_return_value_udf(name: &'static str) -> DataFusionError {
+    let TrustedDataLimits {
+        max_identifier_length,
+        max_aux_string_length,
+        max_depth,
+        max_complexity,
+    } = TrustedDataLimits::default();
+
+    let udf = try_scalar_udfs_with_env(
+        "complex::return_value",
+        &[
+            ("max_identifier_length", &max_identifier_length.to_string()),
+            ("max_aux_string_length", &max_aux_string_length.to_string()),
+            ("max_depth", &max_depth.to_string()),
+            ("max_complexity", &max_complexity.to_string()),
+        ],
+    )
+    .await
+    .unwrap()
+    .into_iter()
+    .find(|udf| udf.name() == name)
+    .unwrap();
 
     udf.invoke_async_with_args(ScalarFunctionArgs {
         args: vec![],


### PR DESCRIPTION
Mostly adds better error context chains, but also actually fixes a bug that that would allow an evil payload to pass very large key-value metadata (limited by the guest memory consumption, but otherwise very large).

Mostly relies on code from #209.

For #16 & #24.