### PR TITLE
refactor: move `WasmPermissions` to dedicated module

### DIFF
--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -2,14 +2,7 @@
 //!
 //!
 //! [DataFusion]: https://datafusion.apache.org/
-use std::{
-    any::Any,
-    collections::{BTreeMap, HashSet},
-    hash::Hash,
-    ops::DerefMut,
-    sync::Arc,
-    time::Duration,
-};
+use std::{any::Any, collections::HashSet, hash::Hash, ops::DerefMut, sync::Arc, time::Duration};
 
 use ::http::HeaderName;
 use arrow::datatypes::DataType;
@@ -56,6 +49,7 @@ pub use crate::{
         HttpRequestValidator, RejectAllHttpRequests,
     },
     limiter::StaticResourceLimits,
+    permissions::WasmPermissions,
     vfs::limits::VfsLimits,
 };
 
@@ -74,6 +68,7 @@ mod http;
 mod ignore_debug;
 mod limiter;
 mod linker;
+mod permissions;
 mod tokio_helpers;
 mod vfs;
 
@@ -231,162 +226,6 @@ impl WasmComponentPrecompiled {
         })
         .await
         .map_err(|e| DataFusionError::External(Box::new(e)))?
-    }
-}
-
-/// Permissions for a WASM component.
-#[derive(Debug)]
-pub struct WasmPermissions {
-    /// Epoch tick time.
-    epoch_tick_time: Duration,
-
-    /// Timeout for blocking tasks, in number of [ticks](Self::epoch_tick_time).
-    ///
-    /// This is stored as tick count instead of a total timeout, since these two variables should be chosen to be
-    /// somewhat consistent. E.g. it makes little sense to massively increase the epoch tick time without also
-    /// increasing the timeout.
-    inplace_blocking_max_ticks: u32,
-
-    /// Validator for HTTP requests.
-    http: Arc<dyn HttpRequestValidator>,
-
-    /// Virtual file system limits.
-    vfs: VfsLimits,
-
-    /// Limit of the stored stderr data.
-    stderr_bytes: usize,
-
-    /// Static resource limits.
-    resource_limits: StaticResourceLimits,
-
-    /// Trusted data limits.
-    trusted_data_limits: TrustedDataLimits,
-
-    /// Maximum number of UDFs.
-    max_udfs: usize,
-
-    /// Environment variables.
-    envs: BTreeMap<String, String>,
-}
-
-impl WasmPermissions {
-    /// Create default permissions.
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
-impl Default for WasmPermissions {
-    fn default() -> Self {
-        let epoch_tick_time = Duration::from_millis(10);
-        let inplace_blocking_timeout = Duration::from_secs(1);
-
-        Self {
-            epoch_tick_time,
-            inplace_blocking_max_ticks: inplace_blocking_timeout
-                .div_duration_f32(epoch_tick_time)
-                .floor() as _,
-            http: Arc::new(RejectAllHttpRequests),
-            vfs: VfsLimits::default(),
-            stderr_bytes: 1024, // 1KB
-            resource_limits: StaticResourceLimits::default(),
-            trusted_data_limits: TrustedDataLimits::default(),
-            max_udfs: 20,
-            envs: BTreeMap::default(),
-        }
-    }
-}
-
-impl WasmPermissions {
-    /// Set epoch tick time.
-    ///
-    /// WASM payload can only be interrupted when the background epoch timer ticks. However, there is a balance
-    /// between too aggressive ticking and potentially longer latency.
-    pub fn with_epoch_tick_time(self, t: Duration) -> Self {
-        Self {
-            epoch_tick_time: t,
-            ..self
-        }
-    }
-
-    /// Set timeout for blocking tasks, in number of [ticks](Self::with_epoch_tick_time).
-    ///
-    /// Exceeding the timeout will result in an error.
-    ///
-    /// This is configured as tick count instead of a total timeout, since these two variables should be chosen to be
-    /// somewhat consistent. E.g. it makes little sense to massively increase the epoch tick time without also
-    /// increasing the timeout.
-    ///
-    /// See <https://github.com/influxdata/datafusion-udf-wasm/issues/169> for a potential better solution in the future.
-    pub fn with_inplace_blocking_max_ticks(self, ticks: u32) -> Self {
-        Self {
-            inplace_blocking_max_ticks: ticks,
-            ..self
-        }
-    }
-
-    /// Set HTTP validator.
-    pub fn with_http<V>(self, http: V) -> Self
-    where
-        V: HttpRequestValidator,
-    {
-        Self {
-            http: Arc::new(http),
-            ..self
-        }
-    }
-
-    /// Limit of the stored stderr data.
-    pub fn with_stderr_bytes(self, limit: usize) -> Self {
-        Self {
-            stderr_bytes: limit,
-            ..self
-        }
-    }
-
-    /// Set static resource limits.
-    ///
-    /// Note that this does NOT limit the overall memory consumption of the payload. This will be done via [`MemoryPool`].
-    pub fn with_resource_limits(self, limits: StaticResourceLimits) -> Self {
-        Self {
-            resource_limits: limits,
-            ..self
-        }
-    }
-
-    /// Set trusted data limits.
-    pub fn with_trusted_data_limits(self, limits: TrustedDataLimits) -> Self {
-        Self {
-            trusted_data_limits: limits,
-            ..self
-        }
-    }
-
-    /// Set virtual filesystem limits.
-    pub fn with_vfs_limits(self, limits: VfsLimits) -> Self {
-        Self {
-            vfs: limits,
-            ..self
-        }
-    }
-
-    /// Get the maximum number of UDFs that a payload/guest can produce.
-    pub fn max_udfs(&self) -> usize {
-        self.max_udfs
-    }
-
-    /// Set the maximum number of UDFs that a payload/guest can produce.
-    pub fn with_max_udfs(self, limit: usize) -> Self {
-        Self {
-            max_udfs: limit,
-            ..self
-        }
-    }
-
-    /// Add environment variable.
-    pub fn with_env(mut self, key: String, value: String) -> Self {
-        self.envs.insert(key, value);
-        self
     }
 }
 

--- a/host/src/permissions.rs
+++ b/host/src/permissions.rs
@@ -1,0 +1,166 @@
+//! Permission for guests.
+
+use std::{collections::BTreeMap, sync::Arc, time::Duration};
+
+use crate::{
+    HttpRequestValidator, RejectAllHttpRequests, StaticResourceLimits, TrustedDataLimits, VfsLimits,
+};
+
+/// Permissions for a WASM component.
+#[derive(Debug)]
+pub struct WasmPermissions {
+    /// Epoch tick time.
+    pub(crate) epoch_tick_time: Duration,
+
+    /// Timeout for blocking tasks, in number of [ticks](Self::epoch_tick_time).
+    ///
+    /// This is stored as tick count instead of a total timeout, since these two variables should be chosen to be
+    /// somewhat consistent. E.g. it makes little sense to massively increase the epoch tick time without also
+    /// increasing the timeout.
+    pub(crate) inplace_blocking_max_ticks: u32,
+
+    /// Validator for HTTP requests.
+    pub(crate) http: Arc<dyn HttpRequestValidator>,
+
+    /// Virtual file system limits.
+    pub(crate) vfs: VfsLimits,
+
+    /// Limit of the stored stderr data.
+    pub(crate) stderr_bytes: usize,
+
+    /// Static resource limits.
+    pub(crate) resource_limits: StaticResourceLimits,
+
+    /// Trusted data limits.
+    pub(crate) trusted_data_limits: TrustedDataLimits,
+
+    /// Maximum number of UDFs.
+    pub(crate) max_udfs: usize,
+
+    /// Environment variables.
+    pub(crate) envs: BTreeMap<String, String>,
+}
+
+impl WasmPermissions {
+    /// Create default permissions.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Default for WasmPermissions {
+    fn default() -> Self {
+        let epoch_tick_time = Duration::from_millis(10);
+        let inplace_blocking_timeout = Duration::from_secs(1);
+
+        Self {
+            epoch_tick_time,
+            inplace_blocking_max_ticks: inplace_blocking_timeout
+                .div_duration_f32(epoch_tick_time)
+                .floor() as _,
+            http: Arc::new(RejectAllHttpRequests),
+            vfs: VfsLimits::default(),
+            stderr_bytes: 1024, // 1KB
+            resource_limits: StaticResourceLimits::default(),
+            trusted_data_limits: TrustedDataLimits::default(),
+            max_udfs: 20,
+            envs: BTreeMap::default(),
+        }
+    }
+}
+
+impl WasmPermissions {
+    /// Set epoch tick time.
+    ///
+    /// WASM payload can only be interrupted when the background epoch timer ticks. However, there is a balance
+    /// between too aggressive ticking and potentially longer latency.
+    pub fn with_epoch_tick_time(self, t: Duration) -> Self {
+        Self {
+            epoch_tick_time: t,
+            ..self
+        }
+    }
+
+    /// Set timeout for blocking tasks, in number of [ticks](Self::with_epoch_tick_time).
+    ///
+    /// Exceeding the timeout will result in an error.
+    ///
+    /// This is configured as tick count instead of a total timeout, since these two variables should be chosen to be
+    /// somewhat consistent. E.g. it makes little sense to massively increase the epoch tick time without also
+    /// increasing the timeout.
+    ///
+    /// See <https://github.com/influxdata/datafusion-udf-wasm/issues/169> for a potential better solution in the future.
+    pub fn with_inplace_blocking_max_ticks(self, ticks: u32) -> Self {
+        Self {
+            inplace_blocking_max_ticks: ticks,
+            ..self
+        }
+    }
+
+    /// Set HTTP validator.
+    pub fn with_http<V>(self, http: V) -> Self
+    where
+        V: HttpRequestValidator,
+    {
+        Self {
+            http: Arc::new(http),
+            ..self
+        }
+    }
+
+    /// Limit of the stored stderr data.
+    pub fn with_stderr_bytes(self, limit: usize) -> Self {
+        Self {
+            stderr_bytes: limit,
+            ..self
+        }
+    }
+
+    /// Set static resource limits.
+    ///
+    /// Note that this does NOT limit the overall memory consumption of the payload. This will be done via [`MemoryPool`].
+    ///
+    ///
+    /// [`MemoryPool`]: datafusion_execution::memory_pool::MemoryPool
+    pub fn with_resource_limits(self, limits: StaticResourceLimits) -> Self {
+        Self {
+            resource_limits: limits,
+            ..self
+        }
+    }
+
+    /// Set trusted data limits.
+    pub fn with_trusted_data_limits(self, limits: TrustedDataLimits) -> Self {
+        Self {
+            trusted_data_limits: limits,
+            ..self
+        }
+    }
+
+    /// Set virtual filesystem limits.
+    pub fn with_vfs_limits(self, limits: VfsLimits) -> Self {
+        Self {
+            vfs: limits,
+            ..self
+        }
+    }
+
+    /// Get the maximum number of UDFs that a payload/guest can produce.
+    pub fn max_udfs(&self) -> usize {
+        self.max_udfs
+    }
+
+    /// Set the maximum number of UDFs that a payload/guest can produce.
+    pub fn with_max_udfs(self, limit: usize) -> Self {
+        Self {
+            max_udfs: limit,
+            ..self
+        }
+    }
+
+    /// Add environment variable.
+    pub fn with_env(mut self, key: String, value: String) -> Self {
+        self.envs.insert(key, value);
+        self
+    }
+}


### PR DESCRIPTION
The `lib.rs` is becoming a bit of a catch-them-all module, so I'm trying to clean this up.