### PR TITLE
refactor: move WASM state to dedicated module

### DIFF
--- a/host/src/linker.rs
+++ b/host/src/linker.rs
@@ -10,8 +10,8 @@ use wasmtime::{
 use wasmtime_wasi::{ResourceTable, WasiView};
 
 use crate::{
-    WasmStateImpl,
     bindings::Datafusion,
+    state::WasmStateImpl,
     vfs::{HasFs, VfsView},
 };
 

--- a/host/src/state.rs
+++ b/host/src/state.rs
@@ -1,0 +1,50 @@
+//! State handling of guests.
+
+use std::sync::Arc;
+
+use tokio::runtime::Handle;
+use wasmtime_wasi::{ResourceTable, WasiCtx, WasiCtxView, WasiView, p2::pipe::MemoryOutputPipe};
+use wasmtime_wasi_http::WasiHttpCtx;
+
+use crate::{HttpRequestValidator, ignore_debug::IgnoreDebug, limiter::Limiter, vfs::VfsState};
+
+/// State of the WASM payload.
+#[derive(Debug)]
+pub(crate) struct WasmStateImpl {
+    /// Virtual filesystem for the WASM payload.
+    ///
+    /// This filesystem is provided to the payload in memory with read-write support.
+    pub(crate) vfs_state: VfsState,
+
+    /// Resource limiter.
+    pub(crate) limiter: Limiter,
+
+    /// A limited buffer for stderr.
+    ///
+    /// This is especially useful for when the payload crashes.
+    pub(crate) stderr: MemoryOutputPipe,
+
+    /// WASI context.
+    pub(crate) wasi_ctx: IgnoreDebug<WasiCtx>,
+
+    /// WASI HTTP context.
+    pub(crate) wasi_http_ctx: WasiHttpCtx,
+
+    /// Resource tables.
+    pub(crate) resource_table: ResourceTable,
+
+    /// HTTP request validator.
+    pub(crate) http_validator: Arc<dyn HttpRequestValidator>,
+
+    /// Handle to tokio I/O runtime.
+    pub(crate) io_rt: Handle,
+}
+
+impl WasiView for WasmStateImpl {
+    fn ctx(&mut self) -> WasiCtxView<'_> {
+        WasiCtxView {
+            ctx: &mut self.wasi_ctx,
+            table: &mut self.resource_table,
+        }
+    }
+}

--- a/host/src/vfs/mod.rs
+++ b/host/src/vfs/mod.rs
@@ -40,6 +40,7 @@ use wasmtime_wasi::{
 use crate::{
     error::LimitExceeded,
     limiter::Limiter,
+    state::WasmStateImpl,
     vfs::{
         limits::VfsLimits,
         path::{PathSegment, PathTraversal},
@@ -48,6 +49,15 @@ use crate::{
 
 pub(crate) mod limits;
 mod path;
+
+impl VfsView for WasmStateImpl {
+    fn vfs(&mut self) -> VfsCtxView<'_> {
+        VfsCtxView {
+            table: &mut self.resource_table,
+            vfs_state: &mut self.vfs_state,
+        }
+    }
+}
 
 /// Shared version of [`VfsNode`].
 type SharedVfsNode = Arc<RwLock<VfsNode>>;


### PR DESCRIPTION
Similar to #234: thinning `lib.rs` a bit and moving the VFS and HTTP parts to their respective modules.