### PR TITLE
refactor: isolate WASM component handling into dedicated module

### DIFF
--- a/host/src/component.rs
+++ b/host/src/component.rs
@@ -1,0 +1,263 @@
+//! WASM component handling.
+use std::{ops::Deref, sync::Arc, time::Duration};
+
+use datafusion_common::{DataFusionError, error::Result as DataFusionResult};
+use datafusion_execution::memory_pool::MemoryPool;
+use tokio::{
+    runtime::Handle,
+    sync::{Mutex, OwnedMutexGuard},
+    task::JoinSet,
+};
+use wasmtime::{
+    AsContext, AsContextMut, Engine, Store, StoreContext, StoreContextMut, UpdateDeadline,
+    component::Component,
+};
+use wasmtime_wasi::{ResourceTable, WasiCtx, p2::pipe::MemoryOutputPipe};
+use wasmtime_wasi_http::WasiHttpCtx;
+
+use crate::{
+    TrustedDataLimits, WasmPermissions, bindings, error::WasmToDataFusionResultExt,
+    ignore_debug::IgnoreDebug, limiter::Limiter, linker::link, state::WasmStateImpl, vfs::VfsState,
+};
+
+/// Create WASM engine.
+fn create_engine() -> DataFusionResult<Engine> {
+    Engine::new(
+        wasmtime::Config::new()
+            .async_support(true)
+            .epoch_interruption(true)
+            .memory_init_cow(true)
+            // Disable backtraces for now since debug info parsing doesn't seem to work and hence error
+            // messages are nondeterministic.
+            .wasm_backtrace(false),
+    )
+    .context("create WASM engine", None)
+}
+
+/// Pre-compiled WASM component.
+///
+/// The pre-compilation is stateless and can be used to [create](crate::WasmScalarUdf::new) multiple instances that do not share
+/// any state.
+#[derive(Debug)]
+pub struct WasmComponentPrecompiled {
+    /// Binary representation of the pre-compiled component.
+    compiled_component: Vec<u8>,
+}
+
+impl WasmComponentPrecompiled {
+    /// Pre-compile WASM payload.
+    ///
+    /// Accepts a WASM payload in [binary format].
+    ///
+    ///
+    /// [binary format]: https://webassembly.github.io/spec/core/binary/index.html
+    pub async fn new(wasm_binary: Arc<[u8]>) -> DataFusionResult<Self> {
+        tokio::task::spawn_blocking(move || {
+            // Create temporary engine that we need for compilation.
+            let engine = create_engine()?;
+
+            let compiled_component = engine
+                .precompile_component(&wasm_binary)
+                .context("pre-compile component", None)?;
+
+            log::debug!(
+                "Pre-compiled {} bytes of WASM bytecode into {} bytes",
+                wasm_binary.len(),
+                compiled_component.len()
+            );
+
+            Ok(Self { compiled_component })
+        })
+        .await
+        .map_err(|e| DataFusionError::External(Box::new(e)))?
+    }
+}
+
+/// Stateful instance of a WASM component.
+#[derive(Debug)]
+pub(crate) struct WasmComponentInstance {
+    /// Mutable state.
+    ///
+    /// This mostly contains [`WasmStateImpl`].
+    store: Arc<Mutex<Store<WasmStateImpl>>>,
+
+    /// Background task that keeps the WASM epoch timer running.
+    #[expect(dead_code)]
+    epoch_task: Arc<JoinSet<()>>,
+
+    /// Timeout for blocking tasks.
+    inplace_blocking_timeout: Duration,
+
+    /// Trusted data limits.
+    trusted_data_limits: TrustedDataLimits,
+
+    /// WIT-based bindings that we resolved within the payload.
+    bindings: IgnoreDebug<Arc<bindings::Datafusion>>,
+}
+
+impl WasmComponentInstance {
+    /// Create new instance.
+    pub(crate) async fn new(
+        component: &WasmComponentPrecompiled,
+        permissions: &WasmPermissions,
+        io_rt: Handle,
+        memory_pool: &Arc<dyn MemoryPool>,
+    ) -> DataFusionResult<Self> {
+        let WasmComponentPrecompiled { compiled_component } = component;
+
+        let engine = create_engine()?;
+
+        // set up epoch timer
+        let mut epoch_task = JoinSet::new();
+        let epoch_tick_time = permissions.epoch_tick_time;
+        let engine_weak = engine.weak();
+        epoch_task.spawn_on(
+            async move {
+                // Create the interval within the I/O runtime so that this runtime drives it, not the CPU runtime.
+                let mut epoch_ticker = tokio::time::interval(epoch_tick_time);
+                epoch_ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+                loop {
+                    epoch_ticker.tick().await;
+
+                    match engine_weak.upgrade() {
+                        Some(engine) => {
+                            engine.increment_epoch();
+                        }
+                        None => {
+                            return;
+                        }
+                    }
+                }
+            },
+            &io_rt,
+        );
+        let epoch_task = Arc::new(epoch_task);
+        let inplace_blocking_timeout = permissions
+            .epoch_tick_time
+            .saturating_mul(permissions.inplace_blocking_max_ticks);
+
+        // SAFETY: the compiled version was produced by us with the same engine. This is NOT external/untrusted input.
+        let component_res = unsafe { Component::deserialize(&engine, compiled_component) };
+        let component = component_res.context("create WASM component", None)?;
+
+        // resource/mem limiter
+        let mut limiter = Limiter::new(permissions.resource_limits.clone(), memory_pool);
+
+        // Create in-memory VFS
+        let vfs_state = VfsState::new(permissions.vfs.clone());
+
+        // set up WASI p2 context
+        limiter.grow(permissions.stderr_bytes)?;
+        let stderr = MemoryOutputPipe::new(permissions.stderr_bytes);
+        let mut wasi_ctx_builder = WasiCtx::builder();
+        wasi_ctx_builder.stderr(stderr.clone());
+        permissions.envs.iter().for_each(|(k, v)| {
+            wasi_ctx_builder.env(k, v);
+        });
+
+        // configure store
+        // NOTE: Do that BEFORE linking so that memory limits are checked for the initial allocation of the WASM
+        //       component as well.
+        let state = WasmStateImpl {
+            vfs_state,
+            limiter,
+            stderr,
+            wasi_ctx: wasi_ctx_builder.build().into(),
+            wasi_http_ctx: WasiHttpCtx::new(),
+            resource_table: ResourceTable::new(),
+            http_validator: Arc::clone(&permissions.http),
+            io_rt,
+        };
+        let mut store = Store::new(&engine, state);
+        store.epoch_deadline_callback(|_| {
+            Ok(UpdateDeadline::YieldCustom(
+                // increment deadline epoch by one step
+                1,
+                // tell tokio that we COULD yield (depending on the remaining cooperative budget)
+                //
+                // NOTE: This future will be executed in the callers context (i.e. whoever is using the WASM UDF code),
+                //       NOT in the context of the epoch background timer.
+                Box::pin(tokio::task::consume_budget()),
+            ))
+        });
+        store.limiter(|state| &mut state.limiter);
+
+        let bindings = link(&engine, &component, &mut store)
+            .await
+            .context("link WASM components", None)?;
+
+        // Populate VFS from tar archive
+        let root_data = bindings
+            .datafusion_udf_wasm_udf_types()
+            .call_root_fs_tar(&mut store)
+            .await
+            .context(
+                "call root_fs_tar() method",
+                Some(&store.data().stderr.contents()),
+            )?;
+        if let Some(root_data) = root_data {
+            let state = store.data_mut();
+
+            state
+                .vfs_state
+                .populate_from_tar(&root_data, &mut state.limiter)
+                .map_err(|e| DataFusionError::IoError(e).context("populate root FS from TAR"))?;
+        }
+
+        let store = Arc::new(Mutex::new(store));
+
+        Ok(Self {
+            store,
+            epoch_task,
+            inplace_blocking_timeout,
+            trusted_data_limits: permissions.trusted_data_limits.clone(),
+            bindings: Arc::clone(&bindings).into(),
+        })
+    }
+
+    /// Get bindings.
+    pub(crate) fn bindings(&self) -> &bindings::Datafusion {
+        &self.bindings
+    }
+
+    /// Lock inner store.
+    pub(crate) async fn lock_state(&self) -> LockedState {
+        LockedState(Arc::clone(&self.store).lock_owned().await)
+    }
+
+    /// Timeout for blocking tasks.
+    pub(crate) fn inplace_blocking_timeout(&self) -> Duration {
+        self.inplace_blocking_timeout
+    }
+
+    /// Trusted data limits.
+    pub(crate) fn trusted_data_limits(&self) -> &TrustedDataLimits {
+        &self.trusted_data_limits
+    }
+}
+
+/// Locked state.
+pub(crate) struct LockedState(OwnedMutexGuard<Store<WasmStateImpl>>);
+
+impl Deref for LockedState {
+    type Target = WasmStateImpl;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.deref().data()
+    }
+}
+
+impl AsContext for LockedState {
+    type Data = WasmStateImpl;
+
+    fn as_context(&self) -> StoreContext<'_, Self::Data> {
+        self.0.as_context()
+    }
+}
+
+impl AsContextMut for LockedState {
+    fn as_context_mut(&mut self) -> StoreContextMut<'_, Self::Data> {
+        self.0.as_context_mut()
+    }
+}

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //!
 //! [DataFusion]: https://datafusion.apache.org/
-use std::{any::Any, collections::HashSet, hash::Hash, ops::DerefMut, sync::Arc, time::Duration};
+use std::{any::Any, collections::HashSet, hash::Hash, sync::Arc};
 
 use arrow::datatypes::DataType;
 use datafusion_common::{DataFusionError, Result as DataFusionResult};
@@ -11,28 +11,21 @@ use datafusion_expr::{
     ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, TypeSignature,
     async_udf::{AsyncScalarUDF, AsyncScalarUDFImpl},
 };
-use tokio::{runtime::Handle, sync::Mutex, task::JoinSet};
+use tokio::runtime::Handle;
 use uuid::Uuid;
-use wasmtime::{
-    Engine, Store, UpdateDeadline,
-    component::{Component, ResourceAny},
-};
-use wasmtime_wasi::{ResourceTable, WasiCtx, async_trait, p2::pipe::MemoryOutputPipe};
-use wasmtime_wasi_http::WasiHttpCtx;
+use wasmtime::component::ResourceAny;
+use wasmtime_wasi::async_trait;
 
 use crate::{
     bindings::exports::datafusion_udf_wasm::udf::types as wit_types,
+    component::WasmComponentInstance,
     conversion::limits::{CheckedInto, ComplexityToken},
     error::{DataFusionResultExt, WasmToDataFusionResultExt, WitDataFusionResultExt},
-    ignore_debug::IgnoreDebug,
-    limiter::Limiter,
-    linker::link,
-    state::WasmStateImpl,
     tokio_helpers::async_in_sync_context,
-    vfs::VfsState,
 };
 
 pub use crate::{
+    component::WasmComponentPrecompiled,
     conversion::limits::TrustedDataLimits,
     http::{
         AllowCertainHttpRequests, HttpMethod, HttpRequestMatcher, HttpRequestRejected,
@@ -52,6 +45,7 @@ use regex as _;
 use wiremock as _;
 
 mod bindings;
+mod component;
 mod conversion;
 mod error;
 mod http;
@@ -62,59 +56,6 @@ mod permissions;
 mod state;
 mod tokio_helpers;
 mod vfs;
-
-/// Create WASM engine.
-fn create_engine() -> DataFusionResult<Engine> {
-    Engine::new(
-        wasmtime::Config::new()
-            .async_support(true)
-            .epoch_interruption(true)
-            .memory_init_cow(true)
-            // Disable backtraces for now since debug info parsing doesn't seem to work and hence error
-            // messages are nondeterministic.
-            .wasm_backtrace(false),
-    )
-    .context("create WASM engine", None)
-}
-
-/// Pre-compiled WASM component.
-///
-/// The pre-compilation is stateless and can be used to [create](WasmScalarUdf::new) multiple instances that do not share
-/// any state.
-#[derive(Debug)]
-pub struct WasmComponentPrecompiled {
-    /// Binary representation of the pre-compiled component.
-    compiled_component: Vec<u8>,
-}
-
-impl WasmComponentPrecompiled {
-    /// Pre-compile WASM payload.
-    ///
-    /// Accepts a WASM payload in [binary format].
-    ///
-    ///
-    /// [binary format]: https://webassembly.github.io/spec/core/binary/index.html
-    pub async fn new(wasm_binary: Arc<[u8]>) -> DataFusionResult<Self> {
-        tokio::task::spawn_blocking(move || {
-            // Create temporary engine that we need for compilation.
-            let engine = create_engine()?;
-
-            let compiled_component = engine
-                .precompile_component(&wasm_binary)
-                .context("pre-compile component", None)?;
-
-            log::debug!(
-                "Pre-compiled {} bytes of WASM bytecode into {} bytes",
-                wasm_binary.len(),
-                compiled_component.len()
-            );
-
-            Ok(Self { compiled_component })
-        })
-        .await
-        .map_err(|e| DataFusionError::External(Box::new(e)))?
-    }
-}
 
 /// A [`ScalarUDFImpl`] that wraps a WebAssembly payload.
 ///
@@ -139,23 +80,8 @@ impl WasmComponentPrecompiled {
 /// [runtime]: tokio::runtime::Runtime
 #[derive(Debug)]
 pub struct WasmScalarUdf {
-    /// Mutable state.
-    ///
-    /// This mostly contains [`WasmStateImpl`].
-    store: Arc<Mutex<Store<WasmStateImpl>>>,
-
-    /// Background task that keeps the WASM epoch timer running.
-    #[expect(dead_code)]
-    epoch_task: Arc<JoinSet<()>>,
-
-    /// Timeout for blocking tasks.
-    inplace_blocking_timeout: Duration,
-
-    /// Trusted data limits.
-    trusted_data_limits: TrustedDataLimits,
-
-    /// WIT-based bindings that we resolved within the payload.
-    bindings: IgnoreDebug<Arc<bindings::Datafusion>>,
+    /// WASM component instance.
+    instance: Arc<WasmComponentInstance>,
 
     /// Resource handle for the Scalar UDF within the VM.
     ///
@@ -199,118 +125,23 @@ impl WasmScalarUdf {
         memory_pool: &Arc<dyn MemoryPool>,
         source: String,
     ) -> DataFusionResult<Vec<Self>> {
-        let WasmComponentPrecompiled { compiled_component } = component;
+        let instance =
+            Arc::new(WasmComponentInstance::new(component, permissions, io_rt, memory_pool).await?);
 
-        let engine = create_engine()?;
-
-        // set up epoch timer
-        let mut epoch_task = JoinSet::new();
-        let epoch_tick_time = permissions.epoch_tick_time;
-        let engine_weak = engine.weak();
-        epoch_task.spawn_on(
-            async move {
-                // Create the interval within the I/O runtime so that this runtime drives it, not the CPU runtime.
-                let mut epoch_ticker = tokio::time::interval(epoch_tick_time);
-                epoch_ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-
-                loop {
-                    epoch_ticker.tick().await;
-
-                    match engine_weak.upgrade() {
-                        Some(engine) => {
-                            engine.increment_epoch();
-                        }
-                        None => {
-                            return;
-                        }
-                    }
-                }
-            },
-            &io_rt,
-        );
-        let epoch_task = Arc::new(epoch_task);
-        let inplace_blocking_timeout = permissions
-            .epoch_tick_time
-            .saturating_mul(permissions.inplace_blocking_max_ticks);
-
-        // SAFETY: the compiled version was produced by us with the same engine. This is NOT external/untrusted input.
-        let component_res = unsafe { Component::deserialize(&engine, compiled_component) };
-        let component = component_res.context("create WASM component", None)?;
-
-        // resource/mem limiter
-        let mut limiter = Limiter::new(permissions.resource_limits.clone(), memory_pool);
-
-        // Create in-memory VFS
-        let vfs_state = VfsState::new(permissions.vfs.clone());
-
-        // set up WASI p2 context
-        limiter.grow(permissions.stderr_bytes)?;
-        let stderr = MemoryOutputPipe::new(permissions.stderr_bytes);
-        let mut wasi_ctx_builder = WasiCtx::builder();
-        wasi_ctx_builder.stderr(stderr.clone());
-        permissions.envs.iter().for_each(|(k, v)| {
-            wasi_ctx_builder.env(k, v);
-        });
-
-        // configure store
-        // NOTE: Do that BEFORE linking so that memory limits are checked for the initial allocation of the WASM
-        //       component as well.
-        let state = WasmStateImpl {
-            vfs_state,
-            limiter,
-            stderr,
-            wasi_ctx: wasi_ctx_builder.build().into(),
-            wasi_http_ctx: WasiHttpCtx::new(),
-            resource_table: ResourceTable::new(),
-            http_validator: Arc::clone(&permissions.http),
-            io_rt,
+        let udf_resources = {
+            let mut state = instance.lock_state().await;
+            instance
+                .bindings()
+                .datafusion_udf_wasm_udf_types()
+                .call_scalar_udfs(&mut state, &source)
+                .await
+                .context(
+                    "calling scalar_udfs() method failed",
+                    Some(&state.stderr.contents()),
+                )?
+                .convert_err(permissions.trusted_data_limits.clone())
+                .context("scalar_udfs")?
         };
-        let mut store = Store::new(&engine, state);
-        store.epoch_deadline_callback(|_| {
-            Ok(UpdateDeadline::YieldCustom(
-                // increment deadline epoch by one step
-                1,
-                // tell tokio that we COULD yield (depending on the remaining cooperative budget)
-                //
-                // NOTE: This future will be executed in the callers context (i.e. whoever is using the WASM UDF code),
-                //       NOT in the context of the epoch background timer.
-                Box::pin(tokio::task::consume_budget()),
-            ))
-        });
-        store.limiter(|state| &mut state.limiter);
-
-        let bindings = link(&engine, &component, &mut store)
-            .await
-            .context("link WASM components", None)?;
-
-        // Populate VFS from tar archive
-        let root_data = bindings
-            .datafusion_udf_wasm_udf_types()
-            .call_root_fs_tar(&mut store)
-            .await
-            .context(
-                "call root_fs_tar() method",
-                Some(&store.data().stderr.contents()),
-            )?;
-        if let Some(root_data) = root_data {
-            let state = store.data_mut();
-
-            state
-                .vfs_state
-                .populate_from_tar(&root_data, &mut state.limiter)
-                .map_err(|e| DataFusionError::IoError(e).context("populate root FS from TAR"))?;
-        }
-
-        let udf_resources = bindings
-            .datafusion_udf_wasm_udf_types()
-            .call_scalar_udfs(&mut store, &source)
-            .await
-            .context(
-                "calling scalar_udfs() method failed",
-                Some(&store.data().stderr.contents()),
-            )?
-            .convert_err(permissions.trusted_data_limits.clone())
-            .context("scalar_udfs")?;
         if udf_resources.len() > permissions.max_udfs {
             return Err(DataFusionError::ResourcesExhausted(format!(
                 "guest returned too many UDFs: got={}, limit={}",
@@ -319,22 +150,17 @@ impl WasmScalarUdf {
             )));
         }
 
-        let store = Arc::new(Mutex::new(store));
-
         let mut udfs = Vec::with_capacity(udf_resources.len());
         let mut names_seen = HashSet::with_capacity(udf_resources.len());
         for resource in udf_resources {
-            let mut store_guard = store.lock().await;
-            let store2: &mut Store<WasmStateImpl> = &mut store_guard;
-            let name = bindings
+            let mut state = instance.lock_state().await;
+            let name = instance
+                .bindings()
                 .datafusion_udf_wasm_udf_types()
                 .scalar_udf()
-                .call_name(store2, resource)
+                .call_name(&mut state, resource)
                 .await
-                .context(
-                    "call ScalarUdf::name",
-                    Some(&store_guard.data().stderr.contents()),
-                )?;
+                .context("call ScalarUdf::name", Some(&state.stderr.contents()))?;
             ComplexityToken::new(permissions.trusted_data_limits.clone())?
                 .check_identifier(&name)
                 .context("UDF name")?;
@@ -344,26 +170,23 @@ impl WasmScalarUdf {
                 ));
             }
 
-            let store2: &mut Store<WasmStateImpl> = &mut store_guard;
-            let signature: Signature = bindings
+            let signature: Signature = instance
+                .bindings()
                 .datafusion_udf_wasm_udf_types()
                 .scalar_udf()
-                .call_signature(store2, resource)
+                .call_signature(&mut state, resource)
                 .await
-                .context(
-                    "call ScalarUdf::signature",
-                    Some(&store_guard.data().stderr.contents()),
-                )?
+                .context("call ScalarUdf::signature", Some(&state.stderr.contents()))?
                 .checked_into_root(&permissions.trusted_data_limits)?;
 
             let return_type = match &signature.type_signature {
                 TypeSignature::Exact(t) => {
-                    let store2: &mut Store<WasmStateImpl> = &mut store_guard;
-                    let r = bindings
+                    let r = instance
+                        .bindings()
                         .datafusion_udf_wasm_udf_types()
                         .scalar_udf()
                         .call_return_type(
-                            store2,
+                            &mut state,
                             resource,
                             &t.iter()
                                 .map(|dt| wit_types::DataType::from(dt.clone()))
@@ -372,7 +195,7 @@ impl WasmScalarUdf {
                         .await
                         .context(
                             "call ScalarUdf::return_type",
-                            Some(&store_guard.data().stderr.contents()),
+                            Some(&state.stderr.contents()),
                         )?
                         .convert_err(permissions.trusted_data_limits.clone())?;
                     Some(r.checked_into_root(&permissions.trusted_data_limits)?)
@@ -381,11 +204,7 @@ impl WasmScalarUdf {
             };
 
             udfs.push(Self {
-                store: Arc::clone(&store),
-                epoch_task: Arc::clone(&epoch_task),
-                inplace_blocking_timeout,
-                trusted_data_limits: permissions.trusted_data_limits.clone(),
-                bindings: Arc::clone(&bindings).into(),
+                instance: Arc::clone(&instance),
                 resource,
                 name,
                 id: Uuid::new_v4(),
@@ -472,21 +291,22 @@ impl ScalarUDFImpl for WasmScalarUdf {
                     .iter()
                     .map(|t| wit_types::DataType::from(t.clone()))
                     .collect::<Vec<_>>();
-                let mut store_guard = self.store.lock().await;
+                let mut state = self.instance.lock_state().await;
                 let return_type = self
-                    .bindings
+                    .instance
+                    .bindings()
                     .datafusion_udf_wasm_udf_types()
                     .scalar_udf()
-                    .call_return_type(store_guard.deref_mut(), self.resource, &arg_types)
+                    .call_return_type(&mut state, self.resource, &arg_types)
                     .await
                     .context(
                         "call ScalarUdf::return_type",
-                        Some(&store_guard.data().stderr.contents()),
+                        Some(&state.stderr.contents()),
                     )?
-                    .convert_err(self.trusted_data_limits.clone())?;
-                return_type.checked_into_root(&self.trusted_data_limits)
+                    .convert_err(self.instance.trusted_data_limits().clone())?;
+                return_type.checked_into_root(self.instance.trusted_data_limits())
             },
-            self.inplace_blocking_timeout,
+            self.instance.inplace_blocking_timeout(),
         )
     }
 
@@ -508,22 +328,21 @@ impl AsyncScalarUDFImpl for WasmScalarUdf {
         args: ScalarFunctionArgs,
     ) -> DataFusionResult<ColumnarValue> {
         let args = args.try_into()?;
-        let mut store_guard = self.store.lock().await;
+        let mut state = self.instance.lock_state().await;
         let return_type = self
-            .bindings
+            .instance
+            .bindings()
             .datafusion_udf_wasm_udf_types()
             .scalar_udf()
-            .call_invoke_with_args(store_guard.deref_mut(), self.resource, &args)
+            .call_invoke_with_args(&mut state, self.resource, &args)
             .await
             .context(
                 "call ScalarUdf::invoke_with_args",
-                Some(&store_guard.data().stderr.contents()),
+                Some(&state.stderr.contents()),
             )?
-            .convert_err(self.trusted_data_limits.clone())?;
+            .convert_err(self.instance.trusted_data_limits().clone())?;
 
-        drop(store_guard);
-
-        match return_type.checked_into_root(&self.trusted_data_limits) {
+        match return_type.checked_into_root(self.instance.trusted_data_limits()) {
             Ok(ColumnarValue::Scalar(scalar)) => Ok(ColumnarValue::Scalar(scalar)),
             Ok(ColumnarValue::Array(array)) if array.len() as u64 != args.number_rows => {
                 Err(DataFusionError::External(


### PR DESCRIPTION
Similar to #235 & #234. This also prepares the codebase for #237 by splitting the actual WASM instance from the UDF type.