### PR TITLE
chore: dowgrade flate to `1.1.5`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1564,9 +1564,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.1.7"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2152dbcb980c05735e2a651d96011320a949eb31a0c8b38b72645ce97dec676"
+checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
 dependencies = [
  "crc32fast",
  "miniz_oxide",

--- a/guests/python/Cargo.toml
+++ b/guests/python/Cargo.toml
@@ -18,7 +18,7 @@ uuid.workspace = true
 wasip2.workspace = true
 
 [build-dependencies]
-flate2 = "1.1.7"
+flate2 = "1.1.5"
 sha2 = "0.10.8"
 tar.workspace = true
 ureq = "3.1.4"


### PR DESCRIPTION
Version `1.1.6` & `1.1.7` got yanked. See

https://github.com/rust-lang/flate2-rs/issues/517
