### PR TITLE
ci: free up more disk space

### DIFF
--- a/.github/actions/free-disk-space/free.sh
+++ b/.github/actions/free-disk-space/free.sh
@@ -5,11 +5,6 @@ set -euo pipefail
 df -h
 
 to_delete=(
-  "/lib/firefox"
-  "/lib/google-cloud-sdk"
-  "/lib/jvm"
-  "/lib/llvm-16"
-  "/lib/llvm-17"
   "/opt/az"
   "/opt/google"
   "/opt/hostedtoolcache/CodeQL"
@@ -19,6 +14,11 @@ to_delete=(
   "/opt/hostedtoolcache/node"
   "/opt/microsoft"
   "/opt/pipx"
+  "/usr/lib/firefox"
+  "/usr/lib/google-cloud-sdk"
+  "/usr/lib/jvm"
+  "/usr/lib/llvm-16"
+  "/usr/lib/llvm-17"
   "/usr/local/.ghcup"
   "/usr/local/lib/android"
   "/usr/share/swift"
@@ -34,6 +34,12 @@ for d in "${to_delete[@]}"; do
 
   if [ -L "$d" ]; then
     echo "directory is a symlink, but we should delete the original source"
+    exit 1
+  fi
+
+  r="$(realpath "$d")"
+  if [ "$d" != "$r" ]; then
+    echo "not a canonical path, use this instead: $r"
     exit 1
   fi
 


### PR DESCRIPTION
#250 lead to a huge recompilation and it turned out that having all crates twice is ever-so-slightly out-of-disk-space. It however also turns out that the runners come with an entire collection of Haskell and Android tooling, that we don't need.