### PR TITLE
ci: use `install-action` to fetch `tombi` instead of `setup-tombi`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,16 +29,10 @@ jobs:
       - name: Install `yamllint`
         run: pip install --requirement=.github/workflows/requirements.txt
 
-      - name: Install `cargo-deny` & `just` & 'typos'
+      - name: Install `cargo-deny` & `just` & `tombi` & 'typos'
         uses: taiki-e/install-action@b9c5db3aef04caffaf95a1d03931de10fb2a140f  # v2
         with:
-          tool: cargo-deny,just,typos
-
-      - name: Install `tombi`
-        uses: tombi-toml/setup-tombi@2119ac80a557c9fb2e7012858e63c22d8bf26cdb  # v1
-        env:
-          # need token to prevent potential rate limiting, see https://github.com/tombi-toml/setup-tombi/issues/9
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          tool: cargo-deny,just,tombi,typos
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9  # master


### PR DESCRIPTION
Advantages:
- as of https://github.com/taiki-e/install-action/pull/1340 `install-action` supports tombi, so we don't need two CI actions to do that
- `install-action` pins the tool version, so `tombi` isn't out of the blue, making the CI less flaky. `setup-tombi` doesn't want to implement that, see https://github.com/tombi-toml/setup-tombi/issues/8#issuecomment-3552831178
- `setup-tombi` is a bit quirky, see https://github.com/tombi-toml/setup-tombi/issues/9
