### PR TITLE
feat: allow building host-side w/o compiler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,13 +24,13 @@ datafusion-common = { version = "50.3.0", default-features = false }
 datafusion-execution = { version = "50.3.0", default-features = false }
 datafusion-expr = { version = "50.3.0", default-features = false }
 datafusion-sql = { version = "50.3.0", default-features = false }
-datafusion-udf-wasm-arrow2bytes = { path = "arrow2bytes", version = "0.1.0" }
-datafusion-udf-wasm-bundle = { path = "guests/bundle", version = "0.1.0" }
-datafusion-udf-wasm-evil = { path = "guests/evil", version = "0.1.0" }
-datafusion-udf-wasm-guest = { path = "guests/rust", version = "0.1.0" }
-datafusion-udf-wasm-host = { path = "host", version = "0.1.0" }
-datafusion-udf-wasm-python = { path = "guests/python", version = "0.1.0" }
-datafusion-udf-wasm-query = { path = "query", version = "0.1.0" }
+datafusion-udf-wasm-arrow2bytes = { path = "arrow2bytes", version = "0.1.0", default-features = false }
+datafusion-udf-wasm-bundle = { path = "guests/bundle", version = "0.1.0", default-features = false }
+datafusion-udf-wasm-evil = { path = "guests/evil", version = "0.1.0", default-features = false }
+datafusion-udf-wasm-guest = { path = "guests/rust", version = "0.1.0", default-features = false }
+datafusion-udf-wasm-host = { path = "host", version = "0.1.0", default-features = false }
+datafusion-udf-wasm-python = { path = "guests/python", version = "0.1.0", default-features = false }
+datafusion-udf-wasm-query = { path = "query", version = "0.1.0", default-features = false }
 http = { version = "1.4.0", default-features = false }
 hyper = { version = "1.8", default-features = false }
 insta = { version = "1.45.1", "default-features" = false }
@@ -49,7 +49,6 @@ uuid = { version = "1.19.0", default-features = false, features = ["v4"] }
 wasip2 = { version = "1" }
 wasmtime = { version = "40.0.0", default-features = false, features = [
   "async",
-  "cranelift"
 ] }
 wasmtime-wasi = { version = "40.0.0", default-features = false }
 wasmtime-wasi-http = { version = "40.0.0", default-features = false, features = [

--- a/Justfile
+++ b/Justfile
@@ -7,9 +7,15 @@ default:
 # check Rust files via `cargo build`
 check-rust-build: guests::rust::check-build guests::python::check-build
 
-# check Rust files via `cargo check`
-check-rust-check $JUSTCHECK="1":
-    @echo ::group::check-rust-check
+# check Rust files via `cargo check` and no default features
+check-rust-check-no-default-features $JUSTCHECK="1":
+    @echo ::group::check-rust-check-no-default-features
+    cargo check --workspace --no-default-features
+    @echo ::endgroup::
+
+# check Rust files via `cargo check` and all features
+check-rust-check-all-features $JUSTCHECK="1":
+    @echo ::group::check-rust-check-all-features
     cargo check --workspace --all-features
     @echo ::endgroup::
 
@@ -50,7 +56,7 @@ check-rust-deny:
     @echo ::endgroup::
 
 # run ALL Rust checks
-check-rust: check-rust-fmt check-rust-check check-rust-build check-rust-clippy check-rust-test check-rust-doc check-rust-bench check-rust-deny
+check-rust: check-rust-fmt check-rust-check-no-default-features check-rust-check-all-features check-rust-build check-rust-clippy check-rust-test check-rust-doc check-rust-bench check-rust-deny
 
 # check spelling
 check-spelling:

--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -41,8 +41,11 @@ tokio = { workspace = true, features = ["fs", "macros"] }
 wiremock = "0.6.5"
 
 [features]
+default = ["compiler"]
 # enable all architectures in cranelift/wasmtime
-all-arch = ["wasmtime/all-arch"]
+all-arch = ["compiler", "wasmtime/all-arch"]
+# allow compilation of WASM bytecode to machine code
+compiler = ["wasmtime/cranelift"]
 
 [lints]
 workspace = true

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -4,7 +4,7 @@
 //! [DataFusion]: https://datafusion.apache.org/
 
 pub use crate::{
-    component::{CompilationFlags, WasmComponentPrecompiled},
+    component::WasmComponentPrecompiled,
     conversion::limits::TrustedDataLimits,
     http::{
         AllowCertainHttpRequests, HttpMethod, HttpRequestMatcher, HttpRequestRejected,
@@ -15,6 +15,9 @@ pub use crate::{
     udf::WasmScalarUdf,
     vfs::limits::VfsLimits,
 };
+
+#[cfg(feature = "compiler")]
+pub use crate::component::CompilationFlags;
 
 // unused-crate-dependencies false positives
 #[cfg(test)]


### PR DESCRIPTION
There is no need in building a compiler when you only want to use pre-built elf binaries (e.g. from our own releases). This can greatly reduce the compilation time and binary size of the host.
