### PR TITLE
refactor: use `Int64` for Rust "add one" example

### DIFF
--- a/guests/rust/examples/add_one.rs
+++ b/guests/rust/examples/add_one.rs
@@ -5,7 +5,7 @@
 
 use std::sync::Arc;
 
-use arrow::{array::Int32Array, datatypes::DataType};
+use arrow::{array::Int64Array, datatypes::DataType};
 use datafusion_common::{
     Result as DataFusionResult, ScalarValue, exec_datafusion_err, exec_err, plan_err,
 };
@@ -24,7 +24,7 @@ struct AddOne {
 impl Default for AddOne {
     fn default() -> Self {
         Self {
-            signature: Signature::uniform(1, vec![DataType::Int32], Volatility::Immutable),
+            signature: Signature::uniform(1, vec![DataType::Int64], Volatility::Immutable),
         }
     }
 }
@@ -46,10 +46,10 @@ impl ScalarUDFImpl for AddOne {
         if arg_types.len() != 1 {
             return plan_err!("add_one expects exactly one argument");
         }
-        if !matches!(arg_types.first(), Some(&DataType::Int32)) {
-            return plan_err!("add_one only accepts Int32 arguments");
+        if !matches!(arg_types.first(), Some(&DataType::Int64)) {
+            return plan_err!("add_one only accepts Int64 arguments");
         }
-        Ok(DataType::Int32)
+        Ok(DataType::Int64)
     }
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> DataFusionResult<ColumnarValue> {
@@ -69,23 +69,23 @@ impl ScalarUDFImpl for AddOne {
             ColumnarValue::Array(array) => {
                 let array = array
                     .as_any()
-                    .downcast_ref::<Int32Array>()
+                    .downcast_ref::<Int64Array>()
                     .ok_or_else(|| exec_datafusion_err!("invalid array type"))?;
 
                 // perform calculation
                 let array = array
                     .iter()
                     .map(|x| x.and_then(|x| x.checked_add(1)))
-                    .collect::<Int32Array>();
+                    .collect::<Int64Array>();
 
                 // create output
                 Ok(ColumnarValue::Array(Arc::new(array)))
             }
             ColumnarValue::Scalar(scalar) => {
-                let ScalarValue::Int32(x) = scalar else {
-                    return exec_err!("add_one only accepts Int32 arguments");
+                let ScalarValue::Int64(x) = scalar else {
+                    return exec_err!("add_one only accepts Int64 arguments");
                 };
-                Ok(ColumnarValue::Scalar(ScalarValue::Int32(
+                Ok(ColumnarValue::Scalar(ScalarValue::Int64(
                     x.and_then(|x| x.checked_add(1)),
                 )))
             }

--- a/host/tests/integration_tests/rust.rs
+++ b/host/tests/integration_tests/rust.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use arrow::{
-    array::{Array, Int32Array},
+    array::{Array, Int64Array},
     datatypes::{DataType, Field},
 };
 use datafusion_common::ScalarValue;
@@ -34,12 +34,12 @@ async fn test_add_one() {
 
     assert_eq!(
         udf.signature(),
-        &Signature::uniform(1, vec![DataType::Int32], Volatility::Immutable),
+        &Signature::uniform(1, vec![DataType::Int64], Volatility::Immutable),
     );
 
     assert_eq!(
-        udf.return_type(&[DataType::Int32]).unwrap(),
-        DataType::Int32,
+        udf.return_type(&[DataType::Int64]).unwrap(),
+        DataType::Int64,
     );
     insta::assert_snapshot!(
         udf.return_type(&[]).unwrap_err(),
@@ -48,14 +48,14 @@ async fn test_add_one() {
 
     let array = udf
         .invoke_async_with_args(ScalarFunctionArgs {
-            args: vec![ColumnarValue::Array(Arc::new(Int32Array::from_iter([
+            args: vec![ColumnarValue::Array(Arc::new(Int64Array::from_iter([
                 Some(3),
                 None,
                 Some(1),
             ])))],
-            arg_fields: vec![Arc::new(Field::new("a1", DataType::Int32, true))],
+            arg_fields: vec![Arc::new(Field::new("a1", DataType::Int64, true))],
             number_rows: 3,
-            return_field: Arc::new(Field::new("r", DataType::Int32, true)),
+            return_field: Arc::new(Field::new("r", DataType::Int64, true)),
             config_options: Arc::new(ConfigOptions::default()),
         })
         .await
@@ -63,21 +63,21 @@ async fn test_add_one() {
         .unwrap_array();
     assert_eq!(
         array.as_ref(),
-        &Int32Array::from_iter([Some(4), None, Some(2)]) as &dyn Array,
+        &Int64Array::from_iter([Some(4), None, Some(2)]) as &dyn Array,
     );
 
     let scalar = udf
         .invoke_async_with_args(ScalarFunctionArgs {
-            args: vec![ColumnarValue::Scalar(ScalarValue::Int32(Some(3)))],
-            arg_fields: vec![Arc::new(Field::new("a1", DataType::Int32, true))],
+            args: vec![ColumnarValue::Scalar(ScalarValue::Int64(Some(3)))],
+            arg_fields: vec![Arc::new(Field::new("a1", DataType::Int64, true))],
             number_rows: 3,
-            return_field: Arc::new(Field::new("r", DataType::Int32, true)),
+            return_field: Arc::new(Field::new("r", DataType::Int64, true)),
             config_options: Arc::new(ConfigOptions::default()),
         })
         .await
         .unwrap()
         .unwrap_scalar();
-    assert_eq!(scalar, ScalarValue::Int32(Some(4)));
+    assert_eq!(scalar, ScalarValue::Int64(Some(4)));
 }
 
 #[tokio::test]
@@ -85,10 +85,10 @@ async fn test_invoke_with_args_returns_error() {
     let udf = udf().await;
 
     let result = udf.invoke_with_args(ScalarFunctionArgs {
-        args: vec![ColumnarValue::Scalar(ScalarValue::Int32(Some(3)))],
-        arg_fields: vec![Arc::new(Field::new("a1", DataType::Int32, true))],
+        args: vec![ColumnarValue::Scalar(ScalarValue::Int64(Some(3)))],
+        arg_fields: vec![Arc::new(Field::new("a1", DataType::Int64, true))],
         number_rows: 3,
-        return_field: Arc::new(Field::new("r", DataType::Int32, true)),
+        return_field: Arc::new(Field::new("r", DataType::Int64, true)),
         config_options: Arc::new(ConfigOptions::default()),
     });
 


### PR DESCRIPTION
That's the same data type that Python uses, so benchmarking that code will be a fairer comparison.

For #28.
