### PR TITLE
refactor: make python guest a "normal" Rust lib

### DIFF
--- a/guests/python/Cargo.toml
+++ b/guests/python/Cargo.toml
@@ -4,9 +4,6 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
-[lib]
-crate-type = ["cdylib"]
-
 [dependencies]
 arrow.workspace = true
 chrono.workspace = true

--- a/guests/python/Justfile
+++ b/guests/python/Justfile
@@ -128,7 +128,7 @@ python-site-packages: download-python-sdk
 [private]
 build-lib profile: download-python-sdk python-site-packages
     @echo ::group::guests::python::build-lib {{profile}}
-    cargo build --target=wasm32-wasip2 --profile={{replace(profile, "debug", "dev")}}
+    cargo rustc --crate-type=cdylib --target=wasm32-wasip2 --profile={{replace(profile, "debug", "dev")}}
     @echo ::endgroup::
 
 # top-level entry point

--- a/guests/python/src/error.rs
+++ b/guests/python/src/error.rs
@@ -46,7 +46,7 @@ pub(crate) trait PyErrExt {
     ///
     /// So this Rust code:
     ///
-    /// ```rust,no-compile
+    /// ```ignore
     /// my_fn
     ///     .call(...)
     ///     .context("foo")

--- a/guests/python/src/lib.rs
+++ b/guests/python/src/lib.rs
@@ -311,7 +311,7 @@ fn init_python() {
 }
 
 /// Generate UDFs from given Python string.
-fn udfs(source: String) -> DataFusionResult<Vec<Arc<dyn ScalarUDFImpl>>> {
+pub fn udfs(source: String) -> DataFusionResult<Vec<Arc<dyn ScalarUDFImpl>>> {
     init_python();
 
     let udfs = inspect_python_code(&source)?;


### PR DESCRIPTION
This is required if we want to consume that code from Rust itself, e.g. to write benchmarks. This also -- out of the sudden -- makes doctests work.

Required for #308.