### PR TITLE
feat(ci): add x86_64-pc-windows-gnu build target

### DIFF
--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -82,6 +82,7 @@ jobs:
             "aarch64-pc-windows-msvc"
             "aarch64-unknown-linux-gnu"
             "x86_64-apple-darwin"
+            "x86_64-pc-windows-gnu"
             "x86_64-pc-windows-msvc"
             "x86_64-unknown-linux-gnu"
           )


### PR DESCRIPTION
InfluxDB Core and Enterprise Windows binaries use the GNU toolchain, not MSVC.
