### PR TITLE
chore: adjust snapshots to Rust 1.93

### DIFF
--- a/host/tests/integration_tests/evil/root.rs
+++ b/host/tests/integration_tests/evil/root.rs
@@ -34,6 +34,7 @@ async fn test_large_file() {
 
     stderr:
     memory allocation of 10485760 bytes failed
+    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 
     caused by
     External error: wasm trap: wasm `unreachable` instruction executed

--- a/host/tests/integration_tests/evil/runtime.rs
+++ b/host/tests/integration_tests/evil/runtime.rs
@@ -34,6 +34,7 @@ async fn test_alloc() {
 
     stderr:
     memory allocation of 1000000000 bytes failed
+    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 
     caused by
     External error: wasm trap: wasm `unreachable` instruction executed


### PR DESCRIPTION
Currently CI fails.
