### PR TITLE
ci: install modern Python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,16 @@ jobs:
         with:
           version-file: "python-tooling/pyproject.toml"
 
+      - name: Install `python`
+        shell: bash
+        run: |
+          uv --directory=python-tooling python install --default
+
+          path_exe="$(uv --directory=python-tooling python find)"
+          path_bin="$(dirname "$path_exe")"
+          echo "PYO3_CROSS_LIB_DIR=${path_bin}/../lib" >> "$GITHUB_ENV"
+          echo "LD_LIBRARY_PATH=${path_bin}/../lib" >> "$GITHUB_ENV"
+
       - name: Install `cargo-deny` & `just` & `tombi` & 'typos'
         uses: taiki-e/install-action@710817a1645ef40daad5bcde7431ceccf6cc3528  # v2
         with:


### PR DESCRIPTION
In most cases we don't really need a host-side Python, but if we want to run benchmarks or tests on the host side (i.e. NOT in WASM) it would be helpful if we would have a proper Python installation.