### PR TITLE
feat: add limiter to VfsState; apply limits to unpacked tar archives

### DIFF
--- a/guests/evil/src/lib.rs
+++ b/guests/evil/src/lib.rs
@@ -104,6 +104,10 @@ impl Evil {
                 root: Box::new(root::not_tar::root),
                 udfs: Box::new(common::udfs_empty),
             },
+            "root::tar_too_large" => Self {
+                root: Box::new(root::tar_too_large::root),
+                udfs: Box::new(common::udfs_empty),
+            },
             "root::path_long" => Self {
                 root: Box::new(root::path_long::root),
                 udfs: Box::new(common::udfs_empty),

--- a/guests/evil/src/root/mod.rs
+++ b/guests/evil/src/root/mod.rs
@@ -5,4 +5,5 @@ pub(crate) mod many_files;
 pub(crate) mod not_tar;
 pub(crate) mod path_long;
 pub(crate) mod sparse;
+pub(crate) mod tar_too_large;
 pub(crate) mod unsupported_entry;

--- a/guests/evil/src/root/tar_too_large.rs
+++ b/guests/evil/src/root/tar_too_large.rs
@@ -1,0 +1,19 @@
+//! Evil payload that returns a tar file that is larger than allowed.
+
+/// Return root file system.
+#[expect(clippy::unnecessary_wraps, reason = "public API through export! macro")]
+pub(crate) fn root() -> Option<Vec<u8>> {
+    let mut ar = tar::Builder::new(Vec::new());
+
+    let tar_size: usize = std::env::var("tar_size").unwrap().parse().unwrap();
+    let data = vec![0u8; tar_size];
+
+    let mut header = tar::Header::new_gnu();
+    header.set_path("foo").unwrap();
+    header.set_size(data.len() as u64);
+    header.set_cksum();
+
+    ar.append(&header, data.as_slice()).unwrap();
+
+    Some(ar.into_inner().unwrap())
+}

--- a/host/src/component.rs
+++ b/host/src/component.rs
@@ -285,7 +285,7 @@ impl WasmComponentInstance {
         let mut limiter = Limiter::new(permissions.resource_limits.clone(), memory_pool);
 
         // Create in-memory VFS
-        let vfs_state = VfsState::new(permissions.vfs.clone());
+        let vfs_state = VfsState::new(permissions.vfs.clone(), limiter.clone());
 
         // set up WASI p2 context
         limiter.grow(permissions.stderr_bytes)?;
@@ -341,7 +341,7 @@ impl WasmComponentInstance {
 
             state
                 .vfs_state
-                .populate_from_tar(&root_data, &mut state.limiter)
+                .populate_from_tar(&root_data)
                 .map_err(|e| DataFusionError::IoError(e).context("populate root FS from TAR"))?;
         }
 


### PR DESCRIPTION
This PR will help #133. It adds the `Limiter` used in `VfsState::populate_from_tar` to the `VfsState` itself; which will allow future, non-implemented `VfsState` trait methods to apply the same resource limits when necessary. It also adds a small evil test to assert that tar archives that are too large will fail to be unpacked.

- [ ] I've read the contributing section of the project [CONTRIBUTING.md](https://github.com/influxdata/datafusion-udf-wasm/blob/main/CONTRIBUTING.md).
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
