### PR TITLE
refactor: cache `Field`/`FieldRef` that passes the host/guest boundary

### DIFF
--- a/guests/rust/src/lib.rs
+++ b/guests/rust/src/lib.rs
@@ -61,6 +61,7 @@ macro_rules! export {
 
         impl $crate::bindings::exports::datafusion_udf_wasm::udf::types::Guest for Implementation {
             type ConfigOptions = $crate::wrapper::ConfigOptionsWrapper;
+            type Field = $crate::wrapper::FieldWrapper;
             type ScalarUdf = $crate::wrapper::ScalarUdfWrapper;
 
             fn root_fs_tar() -> Option<Vec<u8>> {

--- a/host/src/permissions.rs
+++ b/host/src/permissions.rs
@@ -37,6 +37,12 @@ pub struct WasmPermissions {
     /// Maximum number of UDFs.
     pub(crate) max_udfs: usize,
 
+    /// Maximum number of cached [`Field`]s.
+    ///
+    ///
+    /// [`Field`]: arrow::datatypes::Field
+    pub(crate) max_cached_fields: NonZeroUsize,
+
     /// Maximum number of cached [`ConfigOptions`].
     ///
     ///
@@ -70,6 +76,7 @@ impl Default for WasmPermissions {
             resource_limits: StaticResourceLimits::default(),
             trusted_data_limits: TrustedDataLimits::default(),
             max_udfs: 20,
+            max_cached_fields: NonZeroUsize::new(1_000).expect("valid value"),
             max_cached_config_options: NonZeroUsize::new(1).expect("valid value"),
             envs: BTreeMap::default(),
         }
@@ -161,6 +168,17 @@ impl WasmPermissions {
     pub fn with_max_udfs(self, limit: usize) -> Self {
         Self {
             max_udfs: limit,
+            ..self
+        }
+    }
+
+    /// Maximum number of cached [`Field`]s.
+    ///
+    ///
+    /// [`Field`]: arrow::datatypes::Field
+    pub fn with_max_cached_fields(self, limit: NonZeroUsize) -> Self {
+        Self {
+            max_cached_fields: limit,
             ..self
         }
     }

--- a/host/tests/integration_tests/evil/runtime.rs
+++ b/host/tests/integration_tests/evil/runtime.rs
@@ -278,6 +278,8 @@ async fn udf(name: &'static str) -> WasmScalarUdf {
 }
 
 async fn try_call_no_params(udf: &WasmScalarUdf) -> Result<(), DataFusionError> {
+    static RETURN_FIELD: LazyLock<Arc<Field>> =
+        LazyLock::new(|| Arc::new(Field::new("r", DataType::Null, true)));
     static CONFIG_OPTIONS: LazyLock<Arc<ConfigOptions>> =
         LazyLock::new(|| Arc::new(ConfigOptions::default()));
 
@@ -285,7 +287,7 @@ async fn try_call_no_params(udf: &WasmScalarUdf) -> Result<(), DataFusionError> 
         args: vec![],
         arg_fields: vec![],
         number_rows: 1,
-        return_field: Arc::new(Field::new("r", DataType::Null, true)),
+        return_field: Arc::clone(&RETURN_FIELD),
         config_options: Arc::clone(&CONFIG_OPTIONS),
     })
     .await

--- a/wit/world.wit
+++ b/wit/world.wit
@@ -1,4 +1,4 @@
-package datafusion-udf-wasm:udf@0.3.0;
+package datafusion-udf-wasm:udf@0.4.0;
 
 interface types {
     // TODO: add more variants
@@ -20,12 +20,16 @@ interface types {
         arrow-ipc-schema: list<u8>,
     }
 
-    record field {
+    record field-args {
         name: string,
         data-type: data-type,
         nullable: bool,
         dict-is-ordered: bool,
         metadata: list<tuple<string, string>>,
+    }
+
+    resource field {
+        new: static func(args: field-args) -> result<field, data-fusion-error>;
     }
 
     record array {
@@ -84,9 +88,9 @@ interface types {
 
     record scalar-function-args {
         args: list<columnar-value>,
-        arg-fields: list<field>,
+        arg-fields: list<borrow<field>>,
         number-rows: u64,
-        return-field: field,
+        return-field: borrow<field>,
         config-options: borrow<config-options>,
     }
 


### PR DESCRIPTION
Similar to #313 but for `Field`. Reuses the generic infrastructure that was written in #313.

# Performance
If we look at the estimated cycle counts and use the analysis script from #328 we get these results:

**Before:**

```text
=== cost model ===                                                                    
y = cost_row * n_rows + cost_call * n_batches + cost_cached                           
                                                                                      
   cost_row: Cost per input row/cell.                                                 
  cost_call: Cost per UDF call / record batch.                                        
cost_cached: Cost amortized by calling the UDF multiple times.                        
      score: How well the linear model fits (0=not, 1=perfect).                       
┌────────┬──────────┬───────────┬─────────────┬───────┐                               
│ mode   ┆ cost_row ┆ cost_call ┆ cost_cached ┆ score │                               
╞════════╪══════════╪═══════════╪═════════════╪═══════╡                               
│ native ┆      110 ┆         0 ┆      15_665 ┆  1.00 │                               
│ wasm   ┆      472 ┆   943_529 ┆     914_637 ┆  0.99 │                               
│ python ┆    4_983 ┆   959_659 ┆     782_688 ┆  1.00 │                               
└────────┴──────────┴───────────┴─────────────┴───────┘                               
```

**After:**

```text
=== cost model ===                                                                 
y = cost_row * n_rows + cost_call * n_batches + cost_cached                        
                                                                                   
   cost_row: Cost per input row/cell.                                              
  cost_call: Cost per UDF call / record batch.                                     
cost_cached: Cost amortized by calling the UDF multiple times.                     
      score: How well the linear model fits (0=not, 1=perfect).                    
┌────────┬──────────┬───────────┬─────────────┬───────┐                            
│ mode   ┆ cost_row ┆ cost_call ┆ cost_cached ┆ score │                            
╞════════╪══════════╪═══════════╪═════════════╪═══════╡                            
│ native ┆      110 ┆         0 ┆      15_631 ┆  1.00 │                            
│ wasm   ┆      473 ┆   892_156 ┆     936_229 ┆  0.99 │                            
│ python ┆    5_053 ┆   903_482 ┆     726_977 ┆  1.00 │                            
└────────┴──────────┴───────────┴─────────────┴───────┘                            
```

This clearly has an effect. Note though that the benchmark only has 1 argument field and that fields doesn't have any metadata attached. Otherwise the impact would be even bigger. Hence I think this is a worthwhile addition.
