### PR TITLE
feat: implement create_directory_at

### DIFF
--- a/host/src/vfs/mod.rs
+++ b/host/src/vfs/mod.rs
@@ -868,7 +868,9 @@ impl<'a> filesystem::preopens::Host for VfsCtxView<'a> {
         // Create new preopen descriptor for root with read-write access
         let desc = VfsDescriptor {
             node: Arc::clone(&self.vfs_state.root),
-            flags: DescriptorFlags::READ,
+            flags: DescriptorFlags::READ
+                | DescriptorFlags::MUTATE_DIRECTORY
+                | DescriptorFlags::WRITE,
         };
 
         let res = self.table.push(desc)?;

--- a/host/tests/integration_tests/evil/fs.rs
+++ b/host/tests/integration_tests/evil/fs.rs
@@ -838,33 +838,33 @@ async fn test_create_dir() {
     +-------------+-------------------------------------------------+
     | path        | result                                          |
     +-------------+-------------------------------------------------+
-    |             | ERR: Read-only file system (os error 69)        |
-    | .           | ERR: Read-only file system (os error 69)        |
-    | ..          | ERR: Read-only file system (os error 69)        |
-    | /           | ERR: Read-only file system (os error 69)        |
-    | /bin        | ERR: Read-only file system (os error 69)        |
-    | /boot       | ERR: Read-only file system (os error 69)        |
-    | /dev        | ERR: Read-only file system (os error 69)        |
-    | /etc        | ERR: Read-only file system (os error 69)        |
-    | /etc/group  | ERR: Read-only file system (os error 69)        |
-    | /etc/passwd | ERR: Read-only file system (os error 69)        |
-    | /etc/shadow | ERR: Read-only file system (os error 69)        |
-    | /home       | ERR: Read-only file system (os error 69)        |
-    | /lib        | ERR: Read-only file system (os error 69)        |
-    | /lib64      | ERR: Read-only file system (os error 69)        |
-    | /opt        | ERR: Read-only file system (os error 69)        |
-    | /proc       | ERR: Read-only file system (os error 69)        |
-    | /proc/self  | ERR: Read-only file system (os error 69)        |
-    | /root       | ERR: Read-only file system (os error 69)        |
-    | /run        | ERR: Read-only file system (os error 69)        |
-    | /sbin       | ERR: Read-only file system (os error 69)        |
-    | /srv        | ERR: Read-only file system (os error 69)        |
-    | /sys        | ERR: Read-only file system (os error 69)        |
-    | /tmp        | ERR: Read-only file system (os error 69)        |
-    | /usr        | ERR: Read-only file system (os error 69)        |
-    | /var        | ERR: Read-only file system (os error 69)        |
+    |             | ERR: Invalid argument (os error 28)             |
+    | .           | ERR: Invalid argument (os error 28)             |
+    | ..          | ERR: Invalid argument (os error 28)             |
+    | /           | ERR: Invalid argument (os error 28)             |
+    | /bin        | OK: created                                     |
+    | /boot       | OK: created                                     |
+    | /dev        | OK: created                                     |
+    | /etc        | OK: created                                     |
+    | /etc/group  | OK: created                                     |
+    | /etc/passwd | OK: created                                     |
+    | /etc/shadow | OK: created                                     |
+    | /home       | OK: created                                     |
+    | /lib        | OK: created                                     |
+    | /lib64      | OK: created                                     |
+    | /opt        | OK: created                                     |
+    | /proc       | OK: created                                     |
+    | /proc/self  | OK: created                                     |
+    | /root       | OK: created                                     |
+    | /run        | OK: created                                     |
+    | /sbin       | OK: created                                     |
+    | /srv        | OK: created                                     |
+    | /sys        | OK: created                                     |
+    | /tmp        | OK: created                                     |
+    | /usr        | OK: created                                     |
+    | /var        | OK: created                                     |
     | \0          | ERR: file name contained an unexpected NUL byte |
-    | /x/..       | ERR: Read-only file system (os error 69)        |
+    | /x/..       | ERR: Invalid argument (os error 28)             |
     +-------------+-------------------------------------------------+
     ",
     );


### PR DESCRIPTION
This commit implements the `create_directory_at` trait method for the `VfsCtxView`. This will allow guests to create directories on the virtual file system provided by the host. Included as part of this commit are a set of unit tests that assert the following behavior from :
- creating a directory with a read only descriptor fails
- creating a directory that already exists fails
- creating a directory when there are insufficient inodes fails
- creating a directory within a directory succeeds
- creating a directory with an invalid parent fails

Closes #335

_This is basically the same as https://github.com/influxdata/datafusion-udf-wasm/pull/340 but that PR got a little out of hand with trying to manage the commit history._

Describe your proposed changes here.

- [ ] I've read the contributing section of the project [CONTRIBUTING.md](https://github.com/influxdata/datafusion-udf-wasm/blob/main/CONTRIBUTING.md).
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
