### PR TITLE
feat: add "sub str" example

### DIFF
--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -62,6 +62,12 @@ jobs:
       - name: build "add one" example (release)
         run: just guests::rust::build-add-one-release
 
+      - name: build "sub str" example (debug)
+        run: just guests::rust::build-sub-str-debug
+
+      - name: build "sub str" example (release)
+        run: just guests::rust::build-sub-str-release
+
       - name: build python guest (debug)
         run: just guests::python::build-debug
 
@@ -74,6 +80,8 @@ jobs:
           mkdir out
           mv target/wasm32-wasip2/debug/examples/add_one.wasm             out/example_add_one.debug.wasm
           mv target/wasm32-wasip2/release/examples/add_one.wasm           out/example_add_one.release.wasm
+          mv target/wasm32-wasip2/debug/examples/sub_str.wasm             out/example_sub_str.debug.wasm
+          mv target/wasm32-wasip2/release/examples/sub_str.wasm           out/example_sub_str.release.wasm
           mv target/wasm32-wasip2/debug/datafusion_udf_wasm_python.wasm   out/datafusion_udf_wasm_python.debug.wasm
           mv target/wasm32-wasip2/release/datafusion_udf_wasm_python.wasm out/datafusion_udf_wasm_python.release.wasm
 
@@ -162,6 +170,7 @@ jobs:
             We build the following targets:
 
             - `example_add_one`: "add one" Rust example UDF
+            - `example_sub_str`: "sub str" Rust example UDF
             - `datafusion_udf_wasm_python`: Guest for Python-based UDFs, bundles CPython.
 
             Each of them is provided in `debug` and `release` builds. The artifacts have the file extension `.wasm`.

--- a/guests/bundle/build.rs
+++ b/guests/bundle/build.rs
@@ -299,11 +299,18 @@ const FEATURES: &[Feature] = &[
     Feature {
         name: "example",
         package: "datafusion-udf-wasm-guest",
-        just_cmds: &[JustCmd {
-            artifact_type: ArtifactType::Example("add-one"),
-            const_name: "EXAMPLE",
-            doc: r#""add-one" example."#,
-        }],
+        just_cmds: &[
+            JustCmd {
+                artifact_type: ArtifactType::Example("add-one"),
+                const_name: "EXAMPLE_ADD_ONE",
+                doc: r#""add-one" example."#,
+            },
+            JustCmd {
+                artifact_type: ArtifactType::Example("sub-str"),
+                const_name: "EXAMPLE_SUB_STR",
+                doc: r#""sub-str" example."#,
+            },
+        ],
     },
     Feature {
         name: "python",

--- a/guests/rust/Cargo.toml
+++ b/guests/rust/Cargo.toml
@@ -8,6 +8,10 @@ license.workspace = true
 crate-type = ["cdylib"]
 name = "add_one"
 
+[[example]]
+crate-type = ["cdylib"]
+name = "sub_str"
+
 [dependencies]
 arrow.workspace = true
 datafusion-common.workspace = true

--- a/guests/rust/Justfile
+++ b/guests/rust/Justfile
@@ -1,14 +1,20 @@
 [private]
-build-add-one profile:
-    @echo ::group::guests::rust::build-add-one {{profile}}
-    cargo build --target=wasm32-wasip2 --example=add_one --profile={{replace(profile, "debug", "dev")}}
+build-example example profile:
+    @echo ::group::guests::rust::build-{{example}}-{{profile}}
+    cargo build --target=wasm32-wasip2 --example={{example}} --profile={{replace(profile, "debug", "dev")}}
     @echo ::endgroup::
 
 # build `add-one` example in debug mode
-build-add-one-debug: (build-add-one "debug")
+build-add-one-debug: (build-example "add_one" "debug")
 
 # build `add-one` example in release mode
-build-add-one-release: (build-add-one "release")
+build-add-one-release: (build-example "add_one" "release")
+
+# build `sub-str` example in debug mode
+build-sub-str-debug: (build-example "sub_str" "debug")
+
+# build `sub-str` example in release mode
+build-sub-str-release: (build-example "sub_str" "release")
 
 # checks build
-check-build: build-add-one-debug
+check-build: build-add-one-debug build-sub-str-debug

--- a/guests/rust/examples/sub_str.rs
+++ b/guests/rust/examples/sub_str.rs
@@ -1,0 +1,131 @@
+//! Example Scalar UDF that just implements "sub str".
+
+// unused-crate-dependencies false positives
+#![expect(unused_crate_dependencies)]
+
+use std::sync::Arc;
+
+use arrow::{array::StringArray, datatypes::DataType};
+use datafusion_common::{
+    Result as DataFusionResult, ScalarValue, exec_datafusion_err, exec_err, plan_err,
+};
+use datafusion_expr::{ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility};
+use datafusion_udf_wasm_guest::export;
+
+/// UDF that implements "sub str".
+#[derive(Debug, PartialEq, Eq, Hash)]
+struct SubStr {
+    /// Signature of the UDF.
+    ///
+    /// We store this here because [`ScalarUDFImpl::signature`] requires us to return a reference.
+    signature: Signature,
+}
+
+impl Default for SubStr {
+    fn default() -> Self {
+        Self {
+            signature: Signature::uniform(1, vec![DataType::Utf8], Volatility::Immutable),
+        }
+    }
+}
+
+impl ScalarUDFImpl for SubStr {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        "sub_str"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, arg_types: &[DataType]) -> DataFusionResult<DataType> {
+        if arg_types.len() != 1 {
+            return plan_err!("sub_str expects exactly one argument");
+        }
+        if !matches!(arg_types.first(), Some(&DataType::Utf8)) {
+            return plan_err!("sub_str only accepts Utf8 arguments");
+        }
+        Ok(DataType::Utf8)
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> DataFusionResult<ColumnarValue> {
+        let ScalarFunctionArgs {
+            args,
+            arg_fields: _,
+            number_rows: _,
+            return_field: _,
+            config_options: _,
+        } = args;
+
+        // extract inputs
+        if args.len() != 1 {
+            return exec_err!("sub_str expects exactly one argument");
+        }
+        match &args[0] {
+            ColumnarValue::Array(array) => {
+                let array = array
+                    .as_any()
+                    .downcast_ref::<StringArray>()
+                    .ok_or_else(|| exec_datafusion_err!("invalid array type"))?;
+
+                // perform calculation
+                let array = array
+                    .iter()
+                    .map(|x| x.and_then(sub_str))
+                    .collect::<StringArray>();
+
+                // create output
+                Ok(ColumnarValue::Array(Arc::new(array)))
+            }
+            ColumnarValue::Scalar(scalar) => {
+                let ScalarValue::Utf8(s) = scalar else {
+                    return exec_err!("sub_str only accepts Utf8 arguments");
+                };
+                Ok(ColumnarValue::Scalar(ScalarValue::Utf8(
+                    s.as_deref().and_then(sub_str),
+                )))
+            }
+        }
+    }
+}
+
+/// Split string by `.` and get the 2nd substring.
+///
+/// # Examples
+///
+/// | Input           | Output        |
+/// | --------------- | ------------- |
+/// | `""`            | `None`        |
+/// | `"foo"`         | `None`        |
+/// | `"foo."`        | `Some("")`    |
+/// | `"foo.bar"`     | `Some("bar")` |
+/// | `".bar"`        | `Some("bar")` |
+/// | `"foo.bar."`    | `Some("bar")` |
+/// | `"foo.bar.baz"` | `Some("bar")` |
+fn sub_str(s: &str) -> Option<String> {
+    s.split(".").nth(1).map(|s| s.to_owned())
+}
+
+/// Return root file system.
+///
+/// This always returns [`None`] because the example does not need any files.
+fn root() -> Option<Vec<u8>> {
+    None
+}
+
+/// Returns our one example UDF.
+///
+/// The passed `source` is ignored.
+#[expect(clippy::unnecessary_wraps, reason = "public API through export! macro")]
+fn udfs(_source: String) -> DataFusionResult<Vec<Arc<dyn ScalarUDFImpl>>> {
+    Ok(vec![Arc::new(SubStr::default())])
+}
+
+export! {
+    root_fs_tar: root,
+    scalar_udfs: udfs,
+}

--- a/host/benches/udf_overhead.rs
+++ b/host/benches/udf_overhead.rs
@@ -230,7 +230,8 @@ impl Setup {
             Mode::Native => Arc::new(AddOne::default()) as Arc<dyn AsyncScalarUDFImpl>,
             Mode::Wasm => {
                 let udf = rt.block_on(async {
-                    let component = build_wasm_module(datafusion_udf_wasm_bundle::BIN_EXAMPLE);
+                    let component =
+                        build_wasm_module(datafusion_udf_wasm_bundle::BIN_EXAMPLE_ADD_ONE);
 
                     WasmScalarUdf::new(
                         &component,


### PR DESCRIPTION
For #28 we want one example that passes bigger / more complex data around. This simply takes a string, splits it by `.` and returns the 2nd entry (or `None`).