### PR TITLE
chore: pin Rust toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,12 +46,8 @@ jobs:
         with:
           tool: cargo-deny,just,tombi,typos
 
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9  # master
-        with:
-          components: clippy, rustfmt
-          toolchain: stable
-          targets: wasm32-wasip2
+      - name: Install Rust toolchain
+        run: rustup toolchain install
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5  # v2.8.2

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -50,11 +50,8 @@ jobs:
         with:
           tool: just
 
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9  # master
-        with:
-          toolchain: stable
-          targets: wasm32-wasip2
+      - name: Install Rust toolchain
+        run: rustup toolchain install
 
       - name: build "add one" example (debug)
         run: just guests::rust::build-add-one-debug

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.93.1"
+components = ["rustfmt", "clippy"]
+targets = ["wasm32-wasip2"]


### PR DESCRIPTION
Avoids surprises because of:
- failing clippy tests
- ever-so-slightly different snapshot outputs
- discussions about "works for me" (the WASI targets in Rust are kinda new, hence sometimes there are slight behavior differences)