### PR TITLE
fix: `datafusion-udf-wasm-query` test depend on `compiler` feature

### DIFF
--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -16,7 +16,7 @@ tokio.workspace = true
 [dev-dependencies]
 datafusion = { workspace = true, features = ["sql"] }
 datafusion-udf-wasm-bundle = { workspace = true, features = ["python"] }
-datafusion-udf-wasm-host = { workspace = true }
+datafusion-udf-wasm-host = { workspace = true, features = ["compiler"] }
 insta.workspace = true
 
 [lints]


### PR DESCRIPTION
This doesn't occur in CI because there we test all crates in one go, but if you just test the `query` crate (e.g. via your IDE), then this fails to compile.
