### PR TITLE
ci: switch `actions/attest-build-provenance` to `actions/attest`

### DIFF
--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -129,7 +129,7 @@ jobs:
 
       - name: attestation
         id: attestation
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32  # v3
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26  # v4.1.0
         with:
           subject-path: out/*
 


### PR DESCRIPTION
The release announcement of `actions/attest-build-provenance` version 4 reads:

> As of version 4, `actions/attest-build-provenance` is simply a wrapper on top of `actions/attest`.
>
> Existing applications may continue to use the `attest-build-provenance` action, but new implementations should use `actions/attest` instead.

See https://github.com/actions/attest-build-provenance/releases/tag/v4.0.0