### PR TITLE
ci: build docs w/o dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,17 +52,6 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5  # v2.8.2
 
-      # Swatinem/rust-cache does NOT cache docs, see
-      # https://github.com/Swatinem/rust-cache/issues/208
-      - name: Rustdoc Cache
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v4
-        with:
-          path: target/doc
-          key: v0-${{ runner.os }}-rustdoc-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            v0-${{ runner.os }}-rustdoc-${{ hashFiles('**/Cargo.lock') }}
-            v0-${{ runner.os }}-rustdoc-
-
       - name: just check
         run: just check
         env:

--- a/Justfile
+++ b/Justfile
@@ -67,7 +67,7 @@ check-rust-test $RUST_BACKTRACE="1":
 # build Rust docs
 check-rust-doc $JUSTCHECK="1":
     @echo ::group::check-rust-doc
-    cargo doc --document-private-items --all-features --workspace
+    cargo doc --document-private-items --no-deps --all-features --workspace
     @echo ::endgroup::
 
 # dry-run Rust benchmarks


### PR DESCRIPTION
Building docs for ALL dependencies takes a long time. Take this CI job for example that updated the Rust version and hence had to rebuild everything:

https://github.com/influxdata/datafusion-udf-wasm/actions/runs/22858088931/job/66303933630

This took around 1h! 42min of that were spent building docs.

I suspect it's equally bad for developers when they run `just check`.

Also removes the "cache docs" CI steps, since building docs for our own crates should be reasonably fast and we should keep the CI as simple as possible.
