### PR TITLE
test: add tests for malicious VFS write behaviors

### DIFF
--- a/guests/evil/src/fs.rs
+++ b/guests/evil/src/fs.rs
@@ -1,5 +1,5 @@
 //! Payload that interact with the (virtual) file system.
-use std::{hash::Hash, sync::Arc};
+use std::{hash::Hash, io::Write, sync::Arc};
 
 use arrow::{array::StringArray, datatypes::DataType};
 use datafusion_common::{Result as DataFusionResult, cast::as_string_array};
@@ -75,6 +75,167 @@ impl ScalarUDFImpl for String2Udf {
             .collect::<StringArray>();
         Ok(ColumnarValue::Array(Arc::new(array)))
     }
+}
+
+/// Write mode for our write-and-read-back UDFs. This is just a convenient way
+/// to bundle the various options for opening a file for writing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct WriteMode {
+    /// Whether writes append to the file.
+    append: bool,
+    /// Whether the open may create a missing file.
+    create: bool,
+    /// Whether the open must create a new file.
+    create_new: bool,
+    /// Whether the open truncates an existing file first.
+    truncate: bool,
+    /// Whether the open requests write access.
+    write: bool,
+}
+
+impl WriteMode {
+    /// Open an existing file and overwrite bytes in place.
+    const OVERWRITE: Self = Self {
+        append: false,
+        create: false,
+        create_new: false,
+        truncate: false,
+        write: true,
+    };
+
+    /// Open an existing file and truncate it before writing.
+    const TRUNCATE: Self = Self {
+        append: false,
+        create: false,
+        create_new: false,
+        truncate: true,
+        write: true,
+    };
+
+    /// Create the file if it does not exist before writing.
+    const CREATE: Self = Self {
+        append: false,
+        create: true,
+        create_new: false,
+        truncate: false,
+        write: true,
+    };
+
+    /// Require the file to not exist before writing.
+    const CREATE_NEW: Self = Self {
+        append: false,
+        create: false,
+        create_new: true,
+        truncate: false,
+        write: true,
+    };
+}
+
+/// Return a small pre-seeded root filesystem for malicious write tests.
+#[expect(clippy::unnecessary_wraps, reason = "public API through export! macro")]
+pub(crate) fn root() -> Option<Vec<u8>> {
+    let mut ar = tar::Builder::new(Vec::new());
+
+    append_dir(&mut ar, "dir");
+    append_dir(&mut ar, "nested");
+    append_file(&mut ar, "seed.txt", b"seed data");
+    append_file(&mut ar, "nested/child.txt", b"nested data");
+
+    Some(ar.into_inner().unwrap())
+}
+
+/// Append a directory entry to the seeded TAR archive.
+fn append_dir(ar: &mut tar::Builder<Vec<u8>>, path: &str) {
+    let mut header = tar::Header::new_gnu();
+    header.set_entry_type(tar::EntryType::Directory);
+    header.set_mode(0o755);
+    header.set_path(path).unwrap();
+    header.set_size(0);
+    header.set_cksum();
+    ar.append(&header, b"".as_slice()).unwrap();
+}
+
+/// Append a regular file entry to the seeded TAR archive.
+fn append_file(ar: &mut tar::Builder<Vec<u8>>, path: &str, content: &[u8]) {
+    let mut header = tar::Header::new_gnu();
+    header.set_entry_type(tar::EntryType::Regular);
+    header.set_mode(0o644);
+    header.set_path(path).unwrap();
+    header.set_size(content.len() as u64);
+    header.set_cksum();
+    ar.append(&header, content).unwrap();
+}
+
+/// Write content to a path using the configured open mode and then read it back.
+fn write_and_read_back(path: String, content: String, mode: WriteMode) -> Result<String, String> {
+    let mut file = std::fs::File::options()
+        .append(mode.append)
+        .create(mode.create)
+        .create_new(mode.create_new)
+        .read(false)
+        .truncate(mode.truncate)
+        .write(mode.write)
+        .open(&path)
+        .map_err(|e| e.to_string())?;
+
+    file.write_all(content.as_bytes())
+        .map_err(|e| e.to_string())?;
+    drop(file);
+
+    std::fs::read_to_string(path).map_err(|e| e.to_string())
+}
+
+/// Write a large payload in chunks so resource exhaustion happens inside the guest write path.
+fn write_chunked(path: String, size: String) -> Result<String, String> {
+    let mut file = std::fs::File::options()
+        .append(false)
+        .create(true)
+        .create_new(false)
+        .read(false)
+        .truncate(false)
+        .write(true)
+        .open(&path)
+        .map_err(|e| e.to_string())?;
+
+    let mut remaining = size.parse::<usize>().map_err(|e| e.to_string())?;
+    let mut written = 0usize;
+    let chunk = vec![b'x'; 64 * 1024];
+
+    while remaining > 0 {
+        let n = remaining.min(chunk.len());
+        if let Err(e) = file.write_all(&chunk[..n]) {
+            return Err(format!("write failed after {written} bytes: {e}"));
+        }
+        written += n;
+        remaining -= n;
+    }
+
+    Ok(written.to_string())
+}
+
+/// Returns UDFs that perform writes to the filesystem and read back the
+/// results.
+fn seeded_write_udfs() -> Vec<Arc<dyn ScalarUDFImpl>> {
+    vec![
+        Arc::new(String2Udf::new("write_read_back", |path, content| {
+            write_and_read_back(path, content, WriteMode::OVERWRITE)
+        })),
+        Arc::new(String2Udf::new(
+            "truncate_write_read_back",
+            |path, content| write_and_read_back(path, content, WriteMode::TRUNCATE),
+        )),
+        Arc::new(String2Udf::new(
+            "create_write_read_back",
+            |path, content| write_and_read_back(path, content, WriteMode::CREATE),
+        )),
+        Arc::new(String2Udf::new(
+            "create_new_write_read_back",
+            |path, content| write_and_read_back(path, content, WriteMode::CREATE_NEW),
+        )),
+        Arc::new(String2Udf::new("write_chunked", |path, size| {
+            write_chunked(path, size)
+        })),
+    ]
 }
 
 /// Returns our evil UDFs.
@@ -236,4 +397,10 @@ pub(crate) fn udfs(_source: String) -> DataFusionResult<Vec<Arc<dyn ScalarUDFImp
                 .map_err(|e| e.to_string())
         })),
     ])
+}
+
+/// Returns UDFs that perform writes to the filesystem and read back the
+#[expect(clippy::unnecessary_wraps, reason = "public API through export! macro")]
+pub(crate) fn seeded_udfs(_source: String) -> DataFusionResult<Vec<Arc<dyn ScalarUDFImpl>>> {
+    Ok(seeded_write_udfs())
 }

--- a/guests/evil/src/lib.rs
+++ b/guests/evil/src/lib.rs
@@ -80,6 +80,10 @@ impl Evil {
                 root: Box::new(common::root_empty),
                 udfs: Box::new(fs::udfs),
             },
+            "fs::seeded" => Self {
+                root: Box::new(fs::root),
+                udfs: Box::new(fs::seeded_udfs),
+            },
             "net" => Self {
                 root: Box::new(common::root_empty),
                 udfs: Box::new(net::udfs),

--- a/host/tests/integration_tests/evil/fs.rs
+++ b/host/tests/integration_tests/evil/fs.rs
@@ -2909,9 +2909,143 @@ async fn test_symlink_metadata() {
     );
 }
 
+#[derive(Debug)]
+struct WriteCase<'a> {
+    path: &'a str,
+    content: &'a str,
+    expected: &'a str,
+}
+
+#[tokio::test]
+async fn test_seeded_write_read_back() {
+    assert_seeded_write_cases(
+        "write_read_back",
+        &[
+            WriteCase {
+                path: "/seed.txt",
+                content: "overwrite",
+                expected: "OK: overwrite",
+            },
+            WriteCase {
+                path: "/nested/child.txt",
+                content: "nested evil",
+                expected: "OK: nested evil",
+            },
+            WriteCase {
+                path: "/dir",
+                content: "blocked",
+                expected: "ERR: Is a directory (os error 31)",
+            },
+            WriteCase {
+                path: "/etc/passwd",
+                content: "blocked",
+                expected: "ERR: No such file or directory (os error 44)",
+            },
+        ],
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_seeded_truncate_write_read_back() {
+    assert_seeded_write_cases(
+        "truncate_write_read_back",
+        &[
+            WriteCase {
+                path: "/seed.txt",
+                content: "tiny",
+                expected: "OK: tiny",
+            },
+            WriteCase {
+                path: "/nested/child.txt",
+                content: "x",
+                expected: "OK: x",
+            },
+            WriteCase {
+                path: "/dir",
+                content: "blocked",
+                expected: "ERR: Is a directory (os error 31)",
+            },
+        ],
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_seeded_create_write_read_back() {
+    assert_seeded_write_cases(
+        "create_write_read_back",
+        &[
+            WriteCase {
+                path: "/created.txt",
+                content: "fresh",
+                expected: "OK: fresh",
+            },
+            WriteCase {
+                path: "/seed.txt",
+                content: "fresh",
+                expected: "OK: freshdata",
+            },
+            WriteCase {
+                path: "/nested/new.txt",
+                content: "deeper",
+                expected: "OK: deeper",
+            },
+            WriteCase {
+                path: "/missing/new.txt",
+                content: "blocked",
+                expected: "ERR: No such file or directory (os error 44)",
+            },
+            WriteCase {
+                path: "/dir",
+                content: "blocked",
+                expected: "ERR: Is a directory (os error 31)",
+            },
+        ],
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_seeded_create_new_write_read_back() {
+    assert_seeded_write_cases(
+        "create_new_write_read_back",
+        &[
+            WriteCase {
+                path: "/brand-new.txt",
+                content: "fresh",
+                expected: "OK: fresh",
+            },
+            WriteCase {
+                path: "/seed.txt",
+                content: "blocked",
+                expected: "ERR: File exists (os error 20)",
+            },
+        ],
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_seeded_write_chunked_respects_memory_limit() {
+    let size = (16 * 1024 * 1024).to_string();
+    let error = try_invoke_2("fs::seeded", "write_chunked", "/big.txt", &size)
+        .await
+        .unwrap_err();
+
+    assert!(
+        error.contains("insufficient-memory") || error.contains("Resources exhausted"),
+        "unexpected error: {error}"
+    );
+}
+
 /// Get evil UDF.
 async fn udf(name: &'static str) -> WasmScalarUdf {
-    try_scalar_udfs("fs")
+    udf_for("fs", name).await
+}
+
+async fn udf_for(evil: &'static str, name: &'static str) -> WasmScalarUdf {
+    try_scalar_udfs(evil)
         .await
         .unwrap()
         .into_iter()
@@ -2940,6 +3074,55 @@ where
 /// Make path nicely printable.
 fn nice_path(path: &str) -> String {
     path.replace("\0", r#"\0"#)
+}
+
+async fn assert_seeded_write_cases(name: &'static str, cases: &[WriteCase<'_>]) {
+    for case in cases {
+        let result = invoke_2("fs::seeded", name, case.path, case.content).await;
+        assert_eq!(result, case.expected, "unexpected result for {:?}", case);
+    }
+}
+
+async fn invoke_2(evil: &'static str, name: &'static str, a: &str, b: &str) -> String {
+    let udf = udf_for(evil, name).await;
+    try_invoke_2_with_udf(&udf, a, b).await.unwrap()
+}
+
+async fn try_invoke_2(
+    evil: &'static str,
+    name: &'static str,
+    a: &str,
+    b: &str,
+) -> Result<String, String> {
+    let udf = udf_for(evil, name).await;
+    try_invoke_2_with_udf(&udf, a, b).await
+}
+
+async fn try_invoke_2_with_udf(udf: &WasmScalarUdf, a: &str, b: &str) -> Result<String, String> {
+    let result = udf
+        .invoke_async_with_args(ScalarFunctionArgs {
+            args: vec![
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some(a.to_owned()))),
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some(b.to_owned()))),
+            ],
+            arg_fields: vec![
+                Arc::new(Field::new("a", DataType::Utf8, true)),
+                Arc::new(Field::new("b", DataType::Utf8, true)),
+            ],
+            number_rows: 1,
+            return_field: Arc::new(Field::new("result", DataType::Utf8, true)),
+            config_options: Arc::new(ConfigOptions::default()),
+        })
+        .await
+        .map_err(|e| e.to_string())?
+        .unwrap_array();
+
+    Ok(result
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap()
+        .value(0)
+        .to_owned())
 }
 
 /// Run UDF that expects one string input.


### PR DESCRIPTION
Helps (closes?) #339 

This adds some evil tests for testing write behavior. Some abstractions are included to help with readability. For the write tests, a seeded VFS is provided. We then test write behaviors on the seeded VFS. The tests added are:

- write & read back
- *truncated* write & read back
- write & read back with create
  - & create new
- chunked writes respect the VFS memory limit

I've intentionally kept the tests limited. I'm sure we will want more; but it feels like you could keep coming up with things to test. This is a good start.

- [ ] I've read the contributing section of the project [CONTRIBUTING.md](https://github.com/influxdata/datafusion-udf-wasm/blob/main/CONTRIBUTING.md).
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
