### PR TITLE
fix: `wasm-tools` is required for `prebuild` workflow

### DIFF
--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -45,10 +45,10 @@ jobs:
         with:
           version-file: "python-tooling/pyproject.toml"
 
-      - name: Install `just`
+      - name: Install `just` & `wasm-tools`
         uses: taiki-e/install-action@94cb46f8d6e437890146ffbd78a778b78e623fb2  # v2
         with:
-          tool: just
+          tool: just,wasm-tools
           # only allow tools that got pinned via `install-action` to prevent supply chain attacks and surprise-upgrades
           fallback: none
 


### PR DESCRIPTION
This was my oversight in #422 and now fails here:

https://github.com/influxdata/datafusion-udf-wasm/actions/runs/24241047741/job/70775432486