### PR TITLE
refactor: replace `wiremock` with own test harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,16 +297,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "assert-json-diff"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
-dependencies = [
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1466,6 +1456,7 @@ name = "datafusion-udf-wasm-host"
 version = "0.1.0"
 dependencies = [
  "arrow",
+ "bytes",
  "datafusion-common",
  "datafusion-execution",
  "datafusion-expr",
@@ -1477,6 +1468,7 @@ dependencies = [
  "http",
  "http-body-util",
  "hyper",
+ "hyper-util",
  "insta",
  "log",
  "rand 0.10.1",
@@ -1491,7 +1483,6 @@ dependencies = [
  "wasmtime-wasi",
  "wasmtime-wasi-http",
  "wasmtime-wasi-io",
- "wiremock",
 ]
 
 [[package]]
@@ -1526,24 +1517,6 @@ dependencies = [
  "sqlparser",
  "tokio",
 ]
-
-[[package]]
-name = "deadpool"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
-dependencies = [
- "deadpool-runtime",
- "lazy_static",
- "num_cpus",
- "tokio",
-]
-
-[[package]]
-name = "deadpool-runtime"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "derive_more"
@@ -1990,12 +1963,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2032,6 +1999,7 @@ dependencies = [
  "http",
  "http-body",
  "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -2382,12 +2350,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2603,16 +2565,6 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
-dependencies = [
- "hermit-abi",
- "libc",
 ]
 
 [[package]]
@@ -4577,29 +4529,6 @@ checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
  "bitflags",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "wiremock"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
-dependencies = [
- "assert-json-diff",
- "base64",
- "deadpool",
- "futures",
- "http",
- "http-body-util",
- "hyper",
- "hyper-util",
- "log",
- "once_cell",
- "regex",
- "serde",
- "serde_json",
- "tokio",
- "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
 arrow = { version = "57.1.0", default-features = false, features = ["ipc"] }
+bytes = "1.11.1"
 chrono = { version = "0.4.44", default-features = false }
 datafusion = { version = "52.0.0", default-features = false }
 datafusion-common = { version = "52.0.0", default-features = false }
@@ -36,6 +37,7 @@ gungraun = "0.18.1"
 http = { version = "1.4.0", default-features = false }
 http-body-util = "0.1.3"
 hyper = { version = "1.9", default-features = false }
+hyper-util = "0.1.20"
 insta = { version = "1.47.2", "default-features" = false }
 log = { version = "0.4.29", default-features = false }
 pyo3 = { version = "0.28.3", default-features = false, features = ["macros"] }

--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -36,6 +36,7 @@ wasmtime-wasi-http.workspace = true
 wasmtime-wasi-io.workspace = true
 
 [dev-dependencies]
+bytes.workspace = true
 datafusion-udf-wasm-bundle = { workspace = true, features = [
   "evil",
   "example",
@@ -43,11 +44,12 @@ datafusion-udf-wasm-bundle = { workspace = true, features = [
 ] }
 flate2.workspace = true
 gungraun.workspace = true
+http-body-util = { workspace = true, features = ["full"] }
+hyper-util = { workspace = true, features = ["server", "tokio"] }
 insta.workspace = true
 regex.workspace = true
 target-lexicon.workspace = true
 tokio = { workspace = true, features = ["fs", "macros"] }
-wiremock = "0.6.5"
 
 [features]
 default = ["compiler"]

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -21,17 +21,19 @@ pub use crate::component::CompilationFlags;
 
 // unused-crate-dependencies false positives
 #[cfg(test)]
+use bytes as _;
+#[cfg(test)]
 use datafusion_udf_wasm_bundle as _;
 #[cfg(test)]
 use flate2 as _;
 #[cfg(test)]
 use gungraun as _;
 #[cfg(test)]
+use hyper_util as _;
+#[cfg(test)]
 use regex as _;
 #[cfg(test)]
 use target_lexicon as _;
-#[cfg(test)]
-use wiremock as _;
 
 mod bindings;
 mod component;

--- a/host/tests/integration_tests/python/runtime/http/mock_server.rs
+++ b/host/tests/integration_tests/python/runtime/http/mock_server.rs
@@ -1,0 +1,808 @@
+use std::{
+    collections::HashSet,
+    convert::Infallible,
+    net::SocketAddr,
+    sync::{Arc, Mutex},
+};
+
+use bytes::Bytes;
+use http::{HeaderMap, HeaderValue, Method, StatusCode};
+use http_body_util::{BodyExt, Full, combinators::BoxBody};
+use hyper::{body::Incoming, service::service_fn};
+use hyper_util::rt::{TokioExecutor, TokioIo};
+use tokio::{net::TcpListener, task::JoinSet};
+use wasmtime_wasi_http::DEFAULT_FORBIDDEN_HEADERS;
+
+const LISTEN_ADDR: &str = "127.0.0.1:0";
+
+pub(crate) type Request = http::Request<Bytes>;
+pub(crate) type Response = http::Response<BoxBody<Bytes, Infallible>>;
+
+#[derive(Debug, Default)]
+pub(crate) struct Matcher {
+    /// If not [`None`], assert that the method is one of the given ones.
+    pub(crate) method: Option<HashSet<Method>>,
+
+    /// If given, check the path.
+    pub(crate) path: Option<String>,
+
+    /// If given, check that each key-value pair in the header map is contained in the request.
+    ///
+    /// The request may contain extra headers.
+    pub(crate) headers: Option<HeaderMap>,
+
+    /// If given, check the content of the body.
+    pub(crate) body: Option<String>,
+}
+
+impl Matcher {
+    fn matches(&self, req: &Request) -> bool {
+        let Self {
+            method,
+            path,
+            headers,
+            body,
+        } = self;
+
+        if let Some(methods) = method
+            && !methods.contains(req.method())
+        {
+            return false;
+        }
+
+        if let Some(path) = path
+            && path != req.uri().path()
+        {
+            return false;
+        }
+
+        if let Some(headers) = headers
+            && !headers.keys().all(|k| {
+                // Repeated headers may be comma-separated, or actually repeated. We need to deal with both.
+                let has = req
+                    .headers()
+                    .get_all(k)
+                    .iter()
+                    .flat_map(|v| {
+                        v.as_bytes().split(|b| {
+                            char::from_u32(*b as _)
+                                .map(|c| c == ',')
+                                .unwrap_or_default()
+                        })
+                    })
+                    .collect::<HashSet<_>>();
+
+                headers
+                    .get_all(k)
+                    .iter()
+                    .all(|v| has.contains(v.as_bytes()))
+            })
+        {
+            return false;
+        }
+
+        if let Some(body) = body
+            && body.as_bytes() != req.body().as_ref()
+        {
+            return false;
+        }
+
+        true
+    }
+}
+
+pub(crate) trait ResponseGen: std::fmt::Debug + Send + Sync + 'static {
+    fn resp(&self, req: &Request) -> Response;
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct SimpleResponseGen {
+    pub(crate) status: StatusCode,
+    pub(crate) headers: Option<HeaderMap>,
+    pub(crate) body: String,
+}
+
+impl ResponseGen for SimpleResponseGen {
+    fn resp(&self, _req: &Request) -> Response {
+        let Self {
+            status,
+            headers,
+            body,
+        } = self;
+
+        let mut builder = http::Response::builder().status(status);
+
+        if let Some(headers) = headers {
+            *builder.headers_mut().unwrap() = headers.clone();
+        }
+
+        builder
+            .body(Full::new(Bytes::from(body.clone().into_bytes())).boxed())
+            .expect("values provided to the builder should be valid")
+    }
+}
+
+pub(crate) struct ResponseGenFn {
+    f: Box<dyn for<'a> Fn(&'a Request) -> Response + Send + Sync>,
+}
+
+impl ResponseGenFn {
+    pub(crate) fn new<F>(f: F) -> Self
+    where
+        F: for<'a> Fn(&'a Request) -> Response + Send + Sync + 'static,
+    {
+        Self { f: Box::new(f) }
+    }
+}
+
+impl std::fmt::Debug for ResponseGenFn {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ResponseGenFn").finish_non_exhaustive()
+    }
+}
+
+impl ResponseGen for ResponseGenFn {
+    fn resp(&self, req: &Request) -> Response {
+        (self.f)(req)
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct ServerMock {
+    pub(crate) matcher: Matcher,
+    pub(crate) response: Box<dyn ResponseGen>,
+    pub(crate) hits: Option<u64>,
+}
+
+impl Default for ServerMock {
+    fn default() -> Self {
+        Self {
+            matcher: Default::default(),
+            response: Box::new(SimpleResponseGen::default()),
+            hits: Some(1),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct State {
+    mocks: Vec<(ServerMock, u64)>,
+    errors: Vec<String>,
+}
+
+impl State {
+    #[must_use]
+    fn fail(&mut self, msg: impl ToString) -> Response {
+        let msg = msg.to_string();
+        self.errors.push(msg.clone());
+        http::Response::builder()
+            .status(http::StatusCode::BAD_REQUEST)
+            .body(Full::new(Bytes::from(msg.into_bytes())).boxed())
+            .expect("values provided to the builder should be valid")
+    }
+}
+
+type SharedState = Arc<Mutex<State>>;
+
+#[derive(Debug)]
+pub(crate) struct MockServer {
+    _task: JoinSet<()>,
+    state: SharedState,
+    addr: SocketAddr,
+}
+
+impl MockServer {
+    pub(crate) async fn start() -> Self {
+        let tcp_listener = TcpListener::bind(LISTEN_ADDR).await.expect("bind");
+        let addr = tcp_listener.local_addr().unwrap();
+
+        let state = SharedState::default();
+
+        let mut task = JoinSet::new();
+        let state_captured = Arc::clone(&state);
+        task.spawn(async move {
+            let mut connections = JoinSet::new();
+
+            loop {
+                let (stream, accept_addr) = match tcp_listener.accept().await {
+                    Ok(x) => x,
+                    Err(e) => {
+                        eprintln!("failed to accept connection: {e}");
+                        continue;
+                    }
+                };
+
+                let state = Arc::clone(&state_captured);
+                let serve_connection = async move {
+                    let result = hyper_util::server::conn::auto::Builder::new(TokioExecutor::new())
+                        .serve_connection(
+                            TokioIo::new(stream),
+                            service_fn(move |req: http::Request<Incoming>| {
+                                let state = Arc::clone(&state);
+
+                                async move {
+                                    // hydrate entire body so we can process it easier
+                                    let (parts, body) = req.into_parts();
+                                    let body = body.collect().await.unwrap().to_bytes();
+                                    let req = http::Request::from_parts(parts, body);
+
+                                    let mut state = state.lock().unwrap();
+
+                                    if has_forbidden_headers(&req, addr) {
+                                        return Ok(
+                                            state.fail(format!("Forbidden headers:\n{req:#?}"))
+                                        );
+                                    }
+
+                                    let Some((mock, count)) = state
+                                        .mocks
+                                        .iter_mut()
+                                        .find(|(mock, _hits)| mock.matcher.matches(&req))
+                                    else {
+                                        return Ok(state.fail(format!("Not mocked:\n{req:#?}")));
+                                    };
+
+                                    *count += 1;
+
+                                    let mut resp = mock.response.resp(&req);
+
+                                    // combine repeated headers, but we should probably not do that
+                                    // See https://github.com/influxdata/datafusion-udf-wasm/issues/452
+                                    let headers = resp.headers_mut();
+                                    *headers = headers
+                                        .keys()
+                                        .map(|k| {
+                                            let vals = headers
+                                                .get_all(k)
+                                                .iter()
+                                                .map(|v| v.to_str().unwrap())
+                                                .collect::<Vec<_>>();
+                                            let v = HeaderValue::from_str(&vals.join(",")).unwrap();
+                                            (k.clone(), v)
+                                        })
+                                        .collect();
+
+                                    Result::<_, Infallible>::Ok(resp)
+                                }
+                            }),
+                        )
+                        .await;
+
+                    if let Err(e) = result {
+                        eprintln!("error serving {accept_addr}: {e}");
+                    }
+                };
+
+                connections.spawn(serve_connection);
+            }
+        });
+
+        Self {
+            _task: task,
+            state,
+            addr,
+        }
+    }
+
+    pub(crate) fn address(&self) -> SocketAddr {
+        self.addr
+    }
+
+    pub(crate) fn uri(&self) -> String {
+        format!("http://{}", self.addr)
+    }
+
+    pub(crate) fn mock(&self, mock: ServerMock) {
+        self.state.lock().unwrap().mocks.push((mock, 0));
+    }
+}
+
+impl Drop for MockServer {
+    fn drop(&mut self) {
+        let state = self.state.lock().unwrap();
+
+        let mut errors = state.errors.clone();
+
+        // check hit rates
+        for (mock, hits) in &state.mocks {
+            let Some(expected) = mock.hits else {
+                continue;
+            };
+            if *hits != expected {
+                errors.push(format!(
+                    "Should hit {expected} times but got {hits}:\n{mock:#?}",
+                ));
+            }
+        }
+
+        drop(state);
+
+        if !errors.is_empty() {
+            let msg = format!("Errors:\n\n{}", errors.join("\n\n"));
+
+            // don't double-panic
+            if std::thread::panicking() {
+                eprintln!("{msg}");
+            } else {
+                panic!("{msg}");
+            }
+        }
+    }
+}
+
+fn has_forbidden_headers(request: &Request, addr: SocketAddr) -> bool {
+    // "host" is part of the forbidden headers that the client is not supposed to use, but it is set by our own
+    // host HTTP lib
+    if let Some(host_val) = request.headers().get(http::header::HOST)
+        && host_val.to_str().expect("always a string") != addr.to_string()
+    {
+        return true;
+    }
+
+    DEFAULT_FORBIDDEN_HEADERS
+        .iter()
+        .filter(|h| *h != http::header::HOST)
+        .any(|h| request.headers().contains_key(h))
+}
+
+/// Test the tester.
+mod tests {
+    use std::sync::LazyLock;
+
+    use http::HeaderValue;
+    use regex::Regex;
+
+    use super::*;
+
+    #[test]
+    fn test_matcher() {
+        // simple
+        assert!(Matcher::default().matches(&http::Request::builder().body(Bytes::new()).unwrap()));
+
+        // method
+        assert!(
+            Matcher::default().matches(
+                &http::Request::builder()
+                    .method(http::Method::GET)
+                    .body(Bytes::new())
+                    .unwrap()
+            )
+        );
+        assert!(
+            Matcher::default().matches(
+                &http::Request::builder()
+                    .method(http::Method::POST)
+                    .body(Bytes::new())
+                    .unwrap()
+            )
+        );
+        assert!(
+            !Matcher {
+                method: Some(HashSet::from([http::Method::POST])),
+                ..Default::default()
+            }
+            .matches(
+                &http::Request::builder()
+                    .method(http::Method::GET)
+                    .body(Bytes::new())
+                    .unwrap()
+            )
+        );
+
+        // path
+        assert!(
+            Matcher::default().matches(
+                &http::Request::builder()
+                    .uri("http://foo.bar/x")
+                    .body(Bytes::new())
+                    .unwrap()
+            )
+        );
+        assert!(
+            Matcher {
+                path: Some("/x".to_owned()),
+                ..Default::default()
+            }
+            .matches(
+                &http::Request::builder()
+                    .uri("http://foo.bar/x")
+                    .body(Bytes::new())
+                    .unwrap()
+            )
+        );
+        assert!(
+            !Matcher {
+                path: Some("/x/y".to_owned()),
+                ..Default::default()
+            }
+            .matches(
+                &http::Request::builder()
+                    .uri("http://foo.bar/x")
+                    .body(Bytes::new())
+                    .unwrap()
+            )
+        );
+
+        // headers
+        assert!(
+            Matcher::default().matches(
+                &http::Request::builder()
+                    .header(http::header::ACCEPT, "*")
+                    .body(Bytes::new())
+                    .unwrap()
+            )
+        );
+        assert!(
+            Matcher {
+                headers: Some(
+                    [(http::header::ACCEPT, HeaderValue::from_str("foo").unwrap())]
+                        .into_iter()
+                        .collect()
+                ),
+                ..Default::default()
+            }
+            .matches(
+                &http::Request::builder()
+                    .header(http::header::ACCEPT, "foo")
+                    .header(http::header::ACCEPT_RANGES, "bar")
+                    .body(Bytes::new())
+                    .unwrap()
+            )
+        );
+        assert!(
+            !Matcher {
+                headers: Some(
+                    [
+                        (http::header::ACCEPT, HeaderValue::from_str("foo").unwrap()),
+                        (http::header::ACCEPT, HeaderValue::from_str("bar").unwrap())
+                    ]
+                    .into_iter()
+                    .collect()
+                ),
+                ..Default::default()
+            }
+            .matches(
+                &http::Request::builder()
+                    .header(http::header::ACCEPT, "foo")
+                    .header(http::header::ACCEPT, "baz")
+                    .body(Bytes::new())
+                    .unwrap()
+            )
+        );
+        assert!(
+            Matcher {
+                headers: Some(
+                    [
+                        (http::header::ACCEPT, HeaderValue::from_str("foo").unwrap()),
+                        (http::header::ACCEPT, HeaderValue::from_str("bar").unwrap())
+                    ]
+                    .into_iter()
+                    .collect()
+                ),
+                ..Default::default()
+            }
+            .matches(
+                &http::Request::builder()
+                    .header(http::header::ACCEPT, "foo")
+                    .header(http::header::ACCEPT, "bar")
+                    .header(http::header::ACCEPT, "baz")
+                    .body(Bytes::new())
+                    .unwrap()
+            )
+        );
+        assert!(
+            !Matcher {
+                headers: Some(
+                    [
+                        (http::header::ACCEPT, HeaderValue::from_str("foo").unwrap()),
+                        (http::header::ACCEPT, HeaderValue::from_str("bar").unwrap())
+                    ]
+                    .into_iter()
+                    .collect()
+                ),
+                ..Default::default()
+            }
+            .matches(
+                &http::Request::builder()
+                    .header(http::header::ACCEPT, "foo,baz")
+                    .body(Bytes::new())
+                    .unwrap()
+            )
+        );
+        assert!(
+            Matcher {
+                headers: Some(
+                    [
+                        (http::header::ACCEPT, HeaderValue::from_str("foo").unwrap()),
+                        (http::header::ACCEPT, HeaderValue::from_str("bar").unwrap())
+                    ]
+                    .into_iter()
+                    .collect()
+                ),
+                ..Default::default()
+            }
+            .matches(
+                &http::Request::builder()
+                    .header(http::header::ACCEPT, "foo,bar,baz")
+                    .body(Bytes::new())
+                    .unwrap()
+            )
+        );
+
+        // body
+        assert!(
+            Matcher::default().matches(
+                &http::Request::builder()
+                    .body(Bytes::from_static(b"foo"))
+                    .unwrap()
+            )
+        );
+        assert!(
+            Matcher {
+                body: Some("foo".to_owned()),
+                ..Default::default()
+            }
+            .matches(
+                &http::Request::builder()
+                    .body(Bytes::from_static(b"foo"))
+                    .unwrap()
+            )
+        );
+        assert!(
+            !Matcher {
+                body: Some("foo".to_owned()),
+                ..Default::default()
+            }
+            .matches(
+                &http::Request::builder()
+                    .body(Bytes::from_static(b"bar"))
+                    .unwrap()
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn test_default_works() {
+        let server = MockServer::start().await;
+        server.mock(ServerMock::default());
+
+        let resp = reqwest::Client::new()
+            .get(server.uri())
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(resp.text().await.unwrap(), "");
+    }
+
+    #[tokio::test]
+    async fn test_not_hit() {
+        let server = MockServer::start().await;
+        server.mock(ServerMock::default());
+
+        insta::assert_snapshot!(
+            should_panic(move || {
+                drop(server);
+            }),
+            @r#"
+        Errors:
+
+        Should hit 1 times but got 0:
+        ServerMock {
+            matcher: Matcher {
+                method: None,
+                path: None,
+                headers: None,
+                body: None,
+            },
+            response: SimpleResponseGen {
+                status: 200,
+                headers: None,
+                body: "",
+            },
+            hits: Some(
+                1,
+            ),
+        }
+        "#,
+        );
+    }
+
+    #[tokio::test]
+    async fn test_no_double_panic() {
+        let server = MockServer::start().await;
+        server.mock(ServerMock::default());
+
+        insta::assert_snapshot!(
+            should_panic(move || {
+                if true {
+                    panic!("foo");
+                }
+                drop(server);
+            }),
+            @"foo",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_forbidden_headers() {
+        let server = MockServer::start().await;
+
+        let resp = reqwest::Client::new()
+            .get(server.uri())
+            .header(http::header::CONNECTION, "upgrade")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+        insta::assert_snapshot!(
+            normalize_addr(resp.text().await.unwrap()),
+            @r#"
+        Forbidden headers:
+        Request {
+            method: GET,
+            uri: /,
+            version: HTTP/1.1,
+            headers: {
+                "connection": "upgrade",
+                "accept": "*/*",
+                "host": "<ADDR>",
+            },
+            body: b"",
+        }
+        "#,
+        );
+
+        insta::assert_snapshot!(
+            normalize_addr(should_panic(move || {
+                drop(server);
+            })),
+            @r#"
+        Errors:
+
+        Forbidden headers:
+        Request {
+            method: GET,
+            uri: /,
+            version: HTTP/1.1,
+            headers: {
+                "connection": "upgrade",
+                "accept": "*/*",
+                "host": "<ADDR>",
+            },
+            body: b"",
+        }
+        "#,
+        );
+    }
+
+    #[tokio::test]
+    async fn test_wrong_hostname() {
+        let server = MockServer::start().await;
+
+        let resp = reqwest::Client::new()
+            .get(server.uri())
+            .header(http::header::HOST, "foo.bar")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+        insta::assert_snapshot!(
+            normalize_addr(resp.text().await.unwrap()),
+            @r#"
+        Forbidden headers:
+        Request {
+            method: GET,
+            uri: /,
+            version: HTTP/1.1,
+            headers: {
+                "host": "foo.bar",
+                "accept": "*/*",
+            },
+            body: b"",
+        }
+        "#,
+        );
+
+        insta::assert_snapshot!(
+            normalize_addr(should_panic(move || {
+                drop(server);
+            })),
+            @r#"
+        Errors:
+
+        Forbidden headers:
+        Request {
+            method: GET,
+            uri: /,
+            version: HTTP/1.1,
+            headers: {
+                "host": "foo.bar",
+                "accept": "*/*",
+            },
+            body: b"",
+        }
+        "#,
+        );
+    }
+
+    #[tokio::test]
+    async fn test_not_mocked() {
+        let server = MockServer::start().await;
+
+        let resp = reqwest::Client::new()
+            .get(server.uri())
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+        insta::assert_snapshot!(
+            normalize_addr(resp.text().await.unwrap()),
+            @r#"
+        Not mocked:
+        Request {
+            method: GET,
+            uri: /,
+            version: HTTP/1.1,
+            headers: {
+                "accept": "*/*",
+                "host": "<ADDR>",
+            },
+            body: b"",
+        }
+        "#,
+        );
+
+        insta::assert_snapshot!(
+            normalize_addr(should_panic(move || {
+                drop(server);
+            })),
+            @r#"
+        Errors:
+
+        Not mocked:
+        Request {
+            method: GET,
+            uri: /,
+            version: HTTP/1.1,
+            headers: {
+                "accept": "*/*",
+                "host": "<ADDR>",
+            },
+            body: b"",
+        }
+        "#,
+        );
+    }
+
+    fn should_panic<F>(f: F) -> String
+    where
+        F: FnOnce(),
+    {
+        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)) {
+            Ok(()) => panic!("did not panic"),
+            Err(msg) => {
+                if let Some(msg) = msg.downcast_ref::<&str>() {
+                    msg.to_string()
+                } else if let Some(msg) = msg.downcast_ref::<String>() {
+                    msg.clone()
+                } else {
+                    panic!("cannot extract message")
+                }
+            }
+        }
+    }
+
+    /// Normalize addresses since they are not deterministic.
+    fn normalize_addr(e: impl ToString) -> String {
+        let e = e.to_string();
+
+        static REGEX: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new(r#"[0-9]+(\.[0-9]+){3}:[0-9]+"#).unwrap());
+
+        REGEX.replace_all(&e, r#"<ADDR>"#).to_string()
+    }
+}

--- a/host/tests/integration_tests/python/runtime/http/mod.rs
+++ b/host/tests/integration_tests/python/runtime/http/mod.rs
@@ -19,16 +19,26 @@ use datafusion_udf_wasm_host::{
     AllowCertainHttpRequests, HttpConnectionMode, HttpPort, HttpRequestValidator, WasmPermissions,
     WasmScalarUdf,
 };
-use http::header::{ACCEPT_ENCODING, CONTENT_ENCODING};
+use http::{
+    HeaderName, HeaderValue, Method,
+    header::{ACCEPT_ENCODING, CONTENT_ENCODING, CONTENT_TYPE},
+};
+use http_body_util::{BodyExt, Full};
 use regex::Regex;
 use tokio::runtime::Handle;
 use wasmtime_wasi_http::DEFAULT_FORBIDDEN_HEADERS;
-use wiremock::{Mock, MockServer, Request, ResponseTemplate, matchers};
 
 use crate::integration_tests::{
-    python::test_utils::{python_component, python_scalar_udf},
+    python::{
+        runtime::http::mock_server::{
+            Matcher, MockServer, Request, ResponseGenFn, ServerMock, SimpleResponseGen,
+        },
+        test_utils::{python_component, python_scalar_udf},
+    },
     test_utils::ColumnarValueExt,
 };
+
+mod mock_server;
 
 #[tokio::test]
 async fn test_requests_simple() {
@@ -40,11 +50,13 @@ def perform_request(url: str) -> str:
 "#;
 
     let server = MockServer::start().await;
-    Mock::given(matchers::any())
-        .respond_with(ResponseTemplate::new(200).set_body_string("hello world!"))
-        .expect(1)
-        .mount(&server)
-        .await;
+    server.mock(ServerMock {
+        response: Box::new(SimpleResponseGen {
+            body: "hello world!".to_owned(),
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
 
     let mut permissions = AllowCertainHttpRequests::new();
     let endpoint = permissions
@@ -84,11 +96,10 @@ def perform_request(url: str) -> str:
     let udf = python_scalar_udf(CODE).await.unwrap();
 
     let server = MockServer::start().await;
-    Mock::given(matchers::any())
-        .respond_with(ResponseTemplate::new(200))
-        .expect(0)
-        .mount(&server)
-        .await;
+    server.mock(ServerMock {
+        hits: Some(0),
+        ..Default::default()
+    });
 
     let err = udf
         .invoke_async_with_args(ScalarFunctionArgs {
@@ -365,9 +376,7 @@ def test_urllib3(method: str, url: str, headers: str | None, body: str | None) -
     let mut builder_result = StringBuilder::new();
 
     for case in &cases {
-        if let Some(mock) = case.mock(&server, NUMBER_OF_IMPLEMENTATIONS) {
-            mock.mount(&server).await;
-        }
+        case.mock(&server, NUMBER_OF_IMPLEMENTATIONS);
         case.allow(&server, &mut permissions);
 
         let TestCase {
@@ -489,7 +498,7 @@ impl TestCase {
         endpoint.allow_method(self.method.try_into().unwrap());
     }
 
-    fn mock(&self, server: &MockServer, hits: usize) -> Option<Mock> {
+    fn mock(&self, server: &MockServer, hits: usize) {
         let Self {
             base,
             method,
@@ -499,7 +508,7 @@ impl TestCase {
             resp,
         } = self;
         if base.is_some() {
-            return None;
+            return;
         }
 
         let TestResponse {
@@ -508,36 +517,50 @@ impl TestCase {
             body: resp_body,
         } = resp.clone().unwrap_or_default();
 
-        let mut builder = Mock::given(matchers::method(method))
-            .and(matchers::path(path.as_str()))
-            .and(NoForbiddenHeaders::new(
-                server.address().ip().to_string(),
-                server.address().port(),
-            ));
+        let matcher = Matcher {
+            method: Some([Method::try_from(*method).unwrap()].into()),
+            path: Some(path.clone()),
+            headers: Some(
+                requ_headers
+                    .iter()
+                    .filter(|(k, _v)| {
+                        // Python `requests` sends this so we allow it but later drop it from the actual request.
+                        k.as_str() != http::header::CONNECTION
+                    })
+                    .flat_map(|(k, v)| {
+                        let k = HeaderName::try_from(k.clone()).unwrap();
 
-        for (k, v) in requ_headers {
-            // Python `requests` sends this so we allow it but later drop it from the actual request.
-            if k.as_str() == http::header::CONNECTION {
-                continue;
-            }
+                        v.iter()
+                            .map(move |v| (k.clone(), HeaderValue::from_str(v).unwrap()))
+                    })
+                    .collect(),
+            ),
+            body: requ_body.map(|s| s.to_string()),
+        };
 
-            builder = builder.and(matchers::headers(k.as_str(), v.to_vec()));
-        }
+        let response = SimpleResponseGen {
+            status: resp_status.try_into().unwrap(),
+            headers: Some(
+                resp_headers
+                    .iter()
+                    .flat_map(|(k, v)| {
+                        let k = HeaderName::try_from(k.clone()).unwrap();
 
-        if let Some(requ_body) = requ_body {
-            builder = builder.and(matchers::body_string(*requ_body));
-        }
+                        v.iter()
+                            .map(move |v| (k.clone(), HeaderValue::from_str(v).unwrap()))
+                    })
+                    .collect(),
+            ),
+            body: resp_body.map(|s| s.to_owned()).unwrap_or_default(),
+        };
 
-        let mut resp_template = ResponseTemplate::new(resp_status)
-            .append_headers(resp_headers.iter().map(|(k, v)| (k, v.join(","))));
-        if let Some(resp_body) = resp_body {
-            resp_template = resp_template.set_body_string(resp_body);
-        }
+        let hits = if resp.is_ok() { hits as u64 } else { 0 };
 
-        let expect = if resp.is_ok() { hits as u64 } else { 0 };
-
-        let mock = builder.respond_with(resp_template).expect(expect);
-        Some(mock)
+        server.mock(ServerMock {
+            matcher,
+            response: Box::new(response),
+            hits: Some(hits),
+        });
     }
 }
 
@@ -550,35 +573,6 @@ fn headers_to_string(headers: &[(String, &[&str])]) -> Option<String> {
             .map(|(k, v)| format!("{k}:{}", v.join(",")))
             .collect::<Vec<_>>();
         Some(headers.join(";"))
-    }
-}
-
-struct NoForbiddenHeaders {
-    host: String,
-    port: u16,
-}
-
-impl NoForbiddenHeaders {
-    fn new(host: String, port: u16) -> Self {
-        Self { host, port }
-    }
-}
-
-impl wiremock::Match for NoForbiddenHeaders {
-    fn matches(&self, request: &wiremock::Request) -> bool {
-        // "host" is part of the forbidden headers that the client is not supposed to use, but it is set by our own
-        // host HTTP lib
-        let Some(host_val) = request.headers.get(http::header::HOST) else {
-            return false;
-        };
-        if host_val.to_str().expect("always a string") != format!("{}:{}", self.host, self.port) {
-            return false;
-        }
-
-        DEFAULT_FORBIDDEN_HEADERS
-            .iter()
-            .filter(|h| *h != http::header::HOST)
-            .all(|h| !request.headers.contains_key(h))
     }
 }
 
@@ -635,11 +629,13 @@ def perform_request(url: str) -> str:
 
     let server = rt_io.block_on(async {
         let server = MockServer::start().await;
-        Mock::given(matchers::any())
-            .respond_with(ResponseTemplate::new(200).set_body_string("hello world!"))
-            .expect(1)
-            .mount(&server)
-            .await;
+        server.mock(ServerMock {
+            response: Box::new(SimpleResponseGen {
+                body: "hello world!".to_owned(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
         server
     });
 
@@ -735,11 +731,13 @@ async fn assert_large_response_works(code: &'static str) {
     let content = std::iter::repeat_n('x', CONTENT_LEN).collect::<String>();
 
     let server = MockServer::start().await;
-    Mock::given(matchers::any())
-        .respond_with(ResponseTemplate::new(200).set_body_string(&content))
-        .expect(1)
-        .mount(&server)
-        .await;
+    server.mock(ServerMock {
+        response: Box::new(SimpleResponseGen {
+            body: content.to_owned(),
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
 
     let mut permissions = AllowCertainHttpRequests::new();
     let endpoint = permissions
@@ -791,15 +789,19 @@ def perform_request(url: str) -> str:
         let path = format!("/{path_suffix}");
         paths.push(path.clone());
 
-        Mock::given(matchers::path(path))
-            .respond_with(move |req: &Request| {
+        server.mock(ServerMock {
+            matcher: Matcher {
+                path: Some(path),
+                ..Default::default()
+            },
+            response: Box::new(ResponseGenFn::new(move |req: &Request| {
                 // poor man's header parsing
                 //
                 // See:
                 // - https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Accept-Encoding
                 // - https://developer.mozilla.org/en-US/docs/Glossary/Quality_values
                 let accepted = req
-                    .headers
+                    .headers()
                     .get(ACCEPT_ENCODING)
                     .into_iter()
                     .flat_map(|v| v.to_str().unwrap().split(","))
@@ -831,15 +833,16 @@ def perform_request(url: str) -> str:
                     content_encoding = Some(compression.as_str());
                 }
 
-                let mut resp = ResponseTemplate::new(200);
+                let mut resp = http::Response::builder()
+                    .status(200)
+                    .header(CONTENT_TYPE, "text/plain");
                 if let Some(content_encoding) = content_encoding {
-                    resp = resp.append_header(CONTENT_ENCODING, content_encoding);
+                    resp = resp.header(CONTENT_ENCODING, content_encoding);
                 }
-                resp.set_body_raw(body_bytes, "text/plain")
-            })
-            .expect(1)
-            .mount(&server)
-            .await;
+                resp.body(Full::new(body_bytes.into()).boxed()).unwrap()
+            })),
+            ..Default::default()
+        });
     }
 
     let mut permissions = AllowCertainHttpRequests::new();


### PR DESCRIPTION
Reasons:
- there are too many layers of types that transfer/modify things
- we gonna need a test harness that supports TLS/HTTPs
- we need kinda precise control over which protocols are used to know what we're actually testing here
- I wanna use something simple, i.e. not a full-blown "we launch a server in the background" magic thing like `httpmock`
