### PR TITLE
feat: integrate `AllowCertainHttpRequests` into DataFusion configs

### DIFF
--- a/host/src/http/types.rs
+++ b/host/src/http/types.rs
@@ -1,5 +1,5 @@
 //! Common types used for HTTP routines.
-use std::{fmt, num::NonZeroU16};
+use std::{fmt, num::NonZeroU16, str::FromStr};
 
 pub use http::Method as HttpMethod;
 
@@ -76,6 +76,45 @@ impl HttpConnectionMode {
             Self::Encrypted
         } else {
             Self::PlainText
+        }
+    }
+
+    /// Represent mode as string.
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Encrypted => "encrypted",
+            Self::PlainText => "plaintext",
+        }
+    }
+}
+
+impl std::fmt::Display for HttpConnectionMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+/// Invalid [`HttpConnectionMode`].
+#[derive(Debug)]
+pub struct InvalidHttpConnectionMode(String);
+
+impl std::fmt::Display for InvalidHttpConnectionMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Invalid HTTP connection mode: `{}`", self.0)
+    }
+}
+
+impl std::error::Error for InvalidHttpConnectionMode {}
+
+impl FromStr for HttpConnectionMode {
+    type Err = InvalidHttpConnectionMode;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s_lower = s.to_ascii_lowercase();
+        match s_lower.as_str() {
+            "encrypted" => Ok(Self::Encrypted),
+            "plaintext" => Ok(Self::PlainText),
+            _ => Err(InvalidHttpConnectionMode(s.to_owned())),
         }
     }
 }

--- a/host/src/http/validator/allow_certain.rs
+++ b/host/src/http/validator/allow_certain.rs
@@ -2,19 +2,24 @@
 use std::{
     borrow::Cow,
     collections::{HashMap, HashSet},
+    str::FromStr,
 };
 
+use datafusion_common::{DataFusionError, Result as DataFusionResult, config::ConfigField};
 use wasmtime_wasi_http::p2::body::HyperOutgoingBody;
 
-use crate::http::{
-    types::{HttpConnectionMode, HttpMethod, HttpPort},
-    validator::{HttpRequestRejected, HttpRequestValidator},
+use crate::{
+    error::DataFusionResultExt,
+    http::{
+        types::{HttpConnectionMode, HttpMethod, HttpPort},
+        validator::{HttpRequestRejected, HttpRequestValidator},
+    },
 };
 
 /// Allow settings for a given endpoint.
 ///
 /// An endpoint is defined by a host + port.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct AllowHttpEndpoint {
     /// Connection mode.
     mode: HttpConnectionMode,
@@ -24,6 +29,9 @@ pub struct AllowHttpEndpoint {
 }
 
 impl AllowHttpEndpoint {
+    /// Separator for methods.
+    const METHOD_SEP: &str = "|";
+
     /// Allow given connection mode.
     ///
     /// Note that only one mode can be allowed. Calling this method multiple times will keep the last value.
@@ -39,22 +47,114 @@ impl AllowHttpEndpoint {
     }
 }
 
+impl ConfigField for AllowHttpEndpoint {
+    fn visit<V: datafusion_common::config::Visit>(
+        &self,
+        v: &mut V,
+        key: &str,
+        _description: &'static str,
+    ) {
+        let Self { mode, methods } = self;
+
+        v.some(&format!("{key}.mode"), mode, "HTTP connection mode");
+
+        let mut methods = methods.iter().map(|m| m.to_string()).collect::<Vec<_>>();
+        methods.sort_unstable();
+        v.some(
+            &format!("{key}.methods"),
+            methods.join(Self::METHOD_SEP),
+            "HTTP method",
+        );
+    }
+
+    fn set(&mut self, key: &str, value: &str) -> DataFusionResult<()> {
+        match key {
+            "mode" => {
+                let mode: HttpConnectionMode = value.parse().map_err(|e| {
+                    DataFusionError::External(Box::new(e))
+                        .context("cannot parse HTTP connection mode")
+                })?;
+                self.mode = mode;
+                Ok(())
+            }
+            "methods" => {
+                let methods = value
+                    .split(Self::METHOD_SEP)
+                    .map(|s| {
+                        HttpMethod::from_str(s).map_err(|e| {
+                            DataFusionError::External(Box::new(e))
+                                .context("cannot parse HTTP method")
+                        })
+                    })
+                    .collect::<Result<HashSet<_>, _>>()?;
+                self.methods = methods;
+                Ok(())
+            }
+            other => Err(DataFusionError::Configuration(format!(
+                "unknown field: `{other}`"
+            ))),
+        }
+    }
+}
+
 /// Allow settings for a host.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct AllowHttpHost {
     /// Mapping from port to endpoint.
-    endpoints: HashMap<HttpPort, AllowHttpEndpoint>,
+    ports: HashMap<HttpPort, AllowHttpEndpoint>,
 }
 
 impl AllowHttpHost {
     /// Allow given port at this host.
     pub fn allow_port(&mut self, port: HttpPort) -> &mut AllowHttpEndpoint {
-        self.endpoints.entry(port).or_default()
+        self.ports.entry(port).or_default()
+    }
+}
+
+impl ConfigField for AllowHttpHost {
+    fn visit<V: datafusion_common::config::Visit>(
+        &self,
+        v: &mut V,
+        key: &str,
+        _description: &'static str,
+    ) {
+        let Self { ports } = self;
+
+        let mut ports = ports.iter().collect::<Vec<_>>();
+        ports.sort_unstable_by_key(|(port, _cfg)| *port);
+
+        for (port, cfg) in ports {
+            let key = format!("{key}.port.{port}");
+            cfg.visit(v, &key, "");
+        }
+    }
+
+    fn set(&mut self, key: &str, value: &str) -> DataFusionResult<()> {
+        let (field, key) = key.split_once(".").unwrap_or((key, ""));
+
+        match field {
+            "port" => {
+                let (port, key) = key.split_once(".").ok_or_else(|| {
+                    DataFusionError::Configuration(format!(
+                        "port must be terminated by `.`: `{key}`"
+                    ))
+                })?;
+                let port: HttpPort = port
+                    .parse()
+                    .map_err(|e| DataFusionError::External(Box::new(e)).context("parse port"))?;
+                self.allow_port(port)
+                    .set(key, value)
+                    .context("parse port config")
+            }
+            other => Err(DataFusionError::Configuration(format!(
+                "unknown field: `{other}`"
+            ))),
+        }
     }
 }
 
 /// Allow-list requests.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct AllowCertainHttpRequests {
     /// Set of allowed hosts.
     hosts: HashMap<Cow<'static, str>, AllowHttpHost>,
@@ -84,7 +184,7 @@ impl HttpRequestValidator for AllowCertainHttpRequests {
             .ok_or(HttpRequestRejected)?;
 
         let endpoint = host
-            .endpoints
+            .ports
             .get(
                 &request
                     .uri()
@@ -107,8 +207,54 @@ impl HttpRequestValidator for AllowCertainHttpRequests {
     }
 }
 
+impl ConfigField for AllowCertainHttpRequests {
+    fn visit<V: datafusion_common::config::Visit>(
+        &self,
+        v: &mut V,
+        key: &str,
+        _description: &'static str,
+    ) {
+        let Self { hosts } = self;
+
+        let mut hosts = hosts.iter().collect::<Vec<_>>();
+        hosts.sort_unstable_by_key(|(host, _cfg)| *host);
+
+        for (host, cfg) in hosts {
+            let key = format!("{key}.host.[{host}]");
+            cfg.visit(v, &key, "");
+        }
+    }
+
+    fn set(&mut self, key: &str, value: &str) -> DataFusionResult<()> {
+        let (field, key) = key.split_once(".").unwrap_or((key, ""));
+
+        match field {
+            "host" => {
+                let (host, key) = key
+                    .strip_prefix("[")
+                    .and_then(|s| s.split_once("]."))
+                    .ok_or_else(|| {
+                        DataFusionError::Configuration(format!(
+                            "host must be surrounded by `.[` and `].`: `{key}`"
+                        ))
+                    })?;
+                self.allow_host(host.to_owned())
+                    .set(key, value)
+                    .context("parse host config")
+            }
+            other => Err(DataFusionError::Configuration(format!(
+                "unknown field: `{other}`"
+            ))),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
+    use std::fmt::{Display, Write};
+
+    use datafusion_common::config::ConfigEntry;
+
     use super::*;
 
     #[test]
@@ -379,5 +525,205 @@ mod test {
                 .validate(&request_zero_port, HttpConnectionMode::Encrypted)
                 .unwrap_err();
         }
+    }
+
+    #[test]
+    fn test_config_parsing_ok() {
+        let cfg = AllowCertainHttpRequests::default();
+        insta::assert_snapshot!(
+            config_roundtrip(cfg),
+            @"",
+        );
+
+        let mut cfg = AllowCertainHttpRequests::default();
+        cfg.allow_host("foo.bar")
+            .allow_port(HttpPort::new(1337).unwrap())
+            .allow_method(HttpMethod::POST);
+        insta::assert_snapshot!(
+            config_roundtrip(cfg),
+            @r"
+        # HTTP connection mode
+        test.host.[foo.bar].port.1337.mode=encrypted
+
+        # HTTP method
+        test.host.[foo.bar].port.1337.methods=POST
+        ",
+        );
+
+        let mut cfg = AllowCertainHttpRequests::default();
+        let host_1 = cfg.allow_host("foo.bar");
+        let endpoint_1_1 = host_1.allow_port(HttpPort::new(1337).unwrap());
+        endpoint_1_1.allow_mode(HttpConnectionMode::PlainText);
+        endpoint_1_1.allow_method(HttpMethod::POST);
+        endpoint_1_1.allow_method(HttpMethod::GET);
+        let endpoint_1_2 = host_1.allow_port(HttpPort::new(42).unwrap());
+        endpoint_1_2.allow_method(HttpMethod::PATCH);
+        let host_2 = cfg.allow_host("my.com");
+        let endpoint_2_1 = host_2.allow_port(HttpPort::new(1337).unwrap());
+        endpoint_2_1.allow_method(HttpMethod::GET);
+        insta::assert_snapshot!(
+            config_roundtrip(cfg),
+            @r"
+        # HTTP connection mode
+        test.host.[foo.bar].port.42.mode=encrypted
+
+        # HTTP method
+        test.host.[foo.bar].port.42.methods=PATCH
+
+        # HTTP connection mode
+        test.host.[foo.bar].port.1337.mode=plaintext
+
+        # HTTP method
+        test.host.[foo.bar].port.1337.methods=GET|POST
+
+        # HTTP connection mode
+        test.host.[my.com].port.1337.mode=encrypted
+
+        # HTTP method
+        test.host.[my.com].port.1337.methods=GET
+        ",
+        );
+
+        let mut cfg = AllowCertainHttpRequests::default();
+        cfg.allow_host("127.0.0.1")
+            .allow_port(HttpPort::new(1337).unwrap())
+            .allow_method(HttpMethod::POST);
+        cfg.allow_host("::1")
+            .allow_port(HttpPort::new(1337).unwrap())
+            .allow_method(HttpMethod::POST);
+        insta::assert_snapshot!(
+            config_roundtrip(cfg),
+            @r"
+        # HTTP connection mode
+        test.host.[127.0.0.1].port.1337.mode=encrypted
+
+        # HTTP method
+        test.host.[127.0.0.1].port.1337.methods=POST
+
+        # HTTP connection mode
+        test.host.[::1].port.1337.mode=encrypted
+
+        # HTTP method
+        test.host.[::1].port.1337.methods=POST
+        ",
+        );
+    }
+
+    #[test]
+    fn test_config_parsing_err() {
+        insta::assert_snapshot!(
+            config_parsing_err("test.no_such_field=1"),
+            @"Invalid or Unsupported Configuration: unknown field: `no_such_field`",
+        );
+        insta::assert_snapshot!(
+            config_parsing_err("test.host.foo.port.1337.methods=GET"),
+            @"Invalid or Unsupported Configuration: host must be surrounded by `.[` and `].`: `foo.port.1337.methods`",
+        );
+        insta::assert_snapshot!(
+            config_parsing_err("test.host.[foo].port.x.methods=GET"),
+            @r"
+        parse host config
+        caused by
+        parse port
+        caused by
+        External error: invalid digit found in string
+        ",
+        );
+        insta::assert_snapshot!(
+            config_parsing_err("test.host.[foo].port.1337.mode=foo"),
+            @r"
+        parse host config
+        caused by
+        parse port config
+        caused by
+        cannot parse HTTP connection mode
+        caused by
+        External error: Invalid HTTP connection mode: `foo`
+        ",
+        );
+    }
+
+    fn try_config_parsing(txt: &str) -> DataFusionResult<AllowCertainHttpRequests> {
+        let mut cfg = AllowCertainHttpRequests::default();
+        for line in txt.lines() {
+            let line = line.trim();
+            // skip comment / description & empty lines
+            if line.starts_with("#") || line.is_empty() {
+                continue;
+            }
+            let (k, v) = line.split_once("=").unwrap();
+            let k = k.strip_prefix("test.").unwrap();
+            cfg.set(k, v)?;
+        }
+        Ok(cfg)
+    }
+
+    #[track_caller]
+    fn config_parsing_err(txt: &str) -> DataFusionError {
+        try_config_parsing(txt).unwrap_err()
+    }
+
+    #[track_caller]
+    fn config_roundtrip(expected: AllowCertainHttpRequests) -> String {
+        let txt = config_entries_to_txt(&ConfigEntriesCollector::collect(&expected));
+        let actual = match try_config_parsing(&txt) {
+            Ok(actual) => actual,
+            Err(err) => panic!("cannot parse config txt:\n\nErr:\n{err}\n\nText:\n{txt}"),
+        };
+        assert_eq!(actual, expected);
+        txt
+    }
+
+    struct ConfigEntriesCollector(Vec<ConfigEntry>);
+
+    impl ConfigEntriesCollector {
+        fn collect(cfg: &AllowCertainHttpRequests) -> Vec<ConfigEntry> {
+            let mut v = Self(vec![]);
+            cfg.visit(&mut v, "test", "");
+            v.0
+        }
+    }
+
+    impl datafusion_common::config::Visit for ConfigEntriesCollector {
+        fn some<V: Display>(&mut self, key: &str, value: V, description: &'static str) {
+            self.0.push(ConfigEntry {
+                key: key.to_string(),
+                value: Some(value.to_string()),
+                description,
+            });
+        }
+
+        fn none(&mut self, key: &str, description: &'static str) {
+            self.0.push(ConfigEntry {
+                key: key.to_string(),
+                value: None,
+                description,
+            });
+        }
+    }
+
+    fn config_entries_to_txt(entries: &[ConfigEntry]) -> String {
+        let mut out = String::new();
+
+        for (i, entry) in entries.iter().enumerate() {
+            if i > 0 {
+                writeln!(&mut out).unwrap();
+            }
+
+            let ConfigEntry {
+                key,
+                value,
+                description,
+            } = entry;
+            writeln!(&mut out, "# {description}").unwrap();
+
+            if let Some(value) = value {
+                writeln!(&mut out, "{key}={value}").unwrap();
+            } else {
+                writeln!(&mut out, "{key}").unwrap();
+            }
+        }
+
+        out
     }
 }


### PR DESCRIPTION
Currently users of this lib (incl. InfluxDB) have to hand-roll their own config parsing code. Esp. after #429 that's not exactly trivial. Instead of a bunch of downstream implementations, I thought that I may just implement it once and add some proper tests.