### PR TITLE
feat: abstract DNS resolver

### DIFF
--- a/host/src/component.rs
+++ b/host/src/component.rs
@@ -324,7 +324,7 @@ impl WasmComponentInstance {
             stderr,
             wasi_ctx: wasi_ctx_builder.build().into(),
             wasi_http_ctx: WasiHttpCtx::new(),
-            wasi_http_hooks: WasiHttpHooksImpl::new(Arc::clone(&permissions.http), io_rt)
+            wasi_http_hooks: WasiHttpHooksImpl::new(permissions.http.clone(), io_rt)
                 .context("set up HTTP")?,
             resource_table: ResourceTable::new(),
         };

--- a/host/src/http/config.rs
+++ b/host/src/http/config.rs
@@ -1,0 +1,94 @@
+//! Config for HTTP integration.
+
+use std::sync::Arc;
+
+use reqwest::dns::Resolve;
+
+use crate::{HttpRequestValidator, RejectAllHttpRequests, http::dns::ShuffleResolver};
+
+/// HTTP-related configs.
+#[derive(Clone)]
+pub struct HttpConfig {
+    /// Maximum idle connection per host allowed in the pool.
+    pub(crate) pool_max_idle_per_host: usize,
+
+    /// DNS resolver.
+    pub(crate) resolver: Arc<dyn Resolve>,
+
+    /// Validator.
+    pub(crate) validator: Arc<dyn HttpRequestValidator>,
+}
+
+impl HttpConfig {
+    /// Sets the maximum idle connection per host allowed in the pool.
+    ///
+    /// # Default
+    /// Default is `usize::MAX` (no limit).
+    pub fn with_pool_max_idle_per_host(self, max: usize) -> Self {
+        Self {
+            pool_max_idle_per_host: max,
+            ..self
+        }
+    }
+
+    /// Set DNS resolver.
+    ///
+    /// # Implementation
+    /// You may provide any implementation you want, however you MUST make sure that [`Resolve::resolve`] only returns
+    /// [`SocketAddr`](std::net::SocketAddr) with the port set to `0`. Not complying with this requirement will lead to
+    /// "internal" WASI errors.
+    ///
+    /// # Default
+    /// The default is a resolver that uses the operating system (via `libc`) and shuffles the addresses before
+    /// connecting (for better load balancing).
+    pub fn with_resolver<R>(self, resolver: R) -> Self
+    where
+        R: Resolve + 'static,
+    {
+        Self {
+            resolver: Arc::new(resolver),
+            ..self
+        }
+    }
+
+    /// Set HTTP validator.
+    ///
+    /// # Default
+    /// The default is set to ["reject all"](RejectAllHttpRequests).
+    pub fn with_validator<V>(self, validator: V) -> Self
+    where
+        V: HttpRequestValidator,
+    {
+        Self {
+            validator: Arc::new(validator),
+            ..self
+        }
+    }
+}
+
+impl Default for HttpConfig {
+    fn default() -> Self {
+        Self {
+            resolver: Arc::new(ShuffleResolver),
+            pool_max_idle_per_host: usize::MAX,
+            validator: Arc::new(RejectAllHttpRequests),
+        }
+    }
+}
+
+impl std::fmt::Debug for HttpConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self {
+            pool_max_idle_per_host,
+            // doesn't implement Debug
+            resolver: _,
+            validator,
+        } = self;
+
+        f.debug_struct("HttpConfig")
+            .field("pool_max_idle_per_host", pool_max_idle_per_host)
+            .field("resolver", &"<RESOLVER>")
+            .field("validator", validator)
+            .finish()
+    }
+}

--- a/host/src/http/dns.rs
+++ b/host/src/http/dns.rs
@@ -1,0 +1,90 @@
+//! DNS-related tools.
+use std::{net::ToSocketAddrs, sync::Arc};
+
+use rand::prelude::SliceRandom;
+use reqwest::dns::{Addrs, Name, Resolve, Resolving};
+use tokio::task::JoinSet;
+
+/// Dynamic error used by [`Resolve::resolve`].
+type DynErr = Box<dyn std::error::Error + Send + Sync>;
+
+/// DNS resolver that shuffles the response.
+#[derive(Debug)]
+pub(crate) struct ShuffleResolver;
+
+impl Resolve for ShuffleResolver {
+    fn resolve(&self, name: Name) -> Resolving {
+        Box::pin(async move {
+            // use `JoinSet` to propagate cancellation to tasks that haven't started running yet.
+            let mut tasks = JoinSet::new();
+            tasks.spawn_blocking(move || {
+                let it = (name.as_str(), 0).to_socket_addrs()?;
+                let mut addrs = it.collect::<Vec<_>>();
+
+                addrs.shuffle(&mut rand::rng());
+
+                Ok(Box::new(addrs.into_iter()) as Addrs)
+            });
+
+            tasks
+                .join_next()
+                .await
+                .expect("spawned on task")
+                .map_err(|err| Box::new(err) as DynErr)?
+        })
+    }
+}
+
+/// DNS resolver that wraps a user-provided resolver and implements our application logic.
+pub(crate) struct ResolverWrapper {
+    /// User-provided resolver.
+    inner: Arc<dyn Resolve>,
+}
+
+impl ResolverWrapper {
+    /// Create new wrapper.
+    pub(crate) fn new(inner: Arc<dyn Resolve>) -> Self {
+        Self { inner }
+    }
+}
+
+impl Resolve for ResolverWrapper {
+    fn resolve(&self, name: Name) -> Resolving {
+        let inner = Arc::clone(&self.inner);
+
+        Box::pin(async move {
+            let name_string = name.as_str().to_owned();
+            let addrs = inner.resolve(name).await?.collect::<Vec<_>>();
+
+            for addr in &addrs {
+                if addr.port() != 0 {
+                    return Err(Box::new(ResolvedPortNotZero {
+                        name: name_string.clone(),
+                        port: addr.port(),
+                    }) as DynErr);
+                }
+            }
+
+            Ok(Box::new(addrs.into_iter()) as Addrs)
+        })
+    }
+}
+
+/// A user-provided DNS resolver acquired an [`SocketAddr`](std::net::SocketAddr) with a non-zero port.
+#[derive(Debug, Default)]
+pub(crate) struct ResolvedPortNotZero {
+    /// DNS name.
+    name: String,
+
+    /// Port.
+    port: u16,
+}
+
+impl std::fmt::Display for ResolvedPortNotZero {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self { name, port } = self;
+        write!(f, "resolved port for `{name}` is not zero: {port}")
+    }
+}
+
+impl std::error::Error for ResolvedPortNotZero {}

--- a/host/src/http/mod.rs
+++ b/host/src/http/mod.rs
@@ -17,14 +17,20 @@ use wasmtime_wasi_http::{
     },
 };
 
+pub use config::HttpConfig;
 pub use types::{HttpConnectionMode, HttpMethod, HttpPort};
 pub use validator::{
     AllowCertainHttpRequests, AllowHttpEndpoint, AllowHttpHost, HttpRequestRejected,
     HttpRequestValidator, RejectAllHttpRequests,
 };
 
-use crate::state::WasmStateImpl;
+use crate::{
+    http::dns::{ResolvedPortNotZero, ResolverWrapper},
+    state::WasmStateImpl,
+};
 
+mod config;
+mod dns;
 mod types;
 mod validator;
 
@@ -55,10 +61,13 @@ pub(crate) struct WasiHttpHooksImpl {
 
 impl WasiHttpHooksImpl {
     /// Set up data structures.
-    pub(crate) fn new(
-        http_validator: Arc<dyn HttpRequestValidator>,
-        io_rt: Handle,
-    ) -> DataFusionResult<Self> {
+    pub(crate) fn new(config: HttpConfig, io_rt: Handle) -> DataFusionResult<Self> {
+        let HttpConfig {
+            pool_max_idle_per_host,
+            resolver,
+            validator,
+        } = config;
+
         // https://github.com/seanmonstar/reqwest/issues/2924
         if rustls::crypto::CryptoProvider::get_default().is_none() {
             let _ = rustls::crypto::ring::default_provider().install_default();
@@ -76,17 +85,18 @@ impl WasiHttpHooksImpl {
             // TODO: allow overrides
             .no_proxy()
             // set up DNS
-            // TODO: allow overrides
-            .no_hickory_dns()
+            .dns_resolver(ResolverWrapper::new(resolver))
             // TLS setup
             // TODO: allow admin to set CA etc.
             .tls_backend_rustls()
+            // connection pool setup
+            .pool_max_idle_per_host(pool_max_idle_per_host)
             // done
             .build()
             .map_err(|e| DataFusionError::External(Box::new(e)))?;
 
         Ok(Self {
-            http_validator,
+            http_validator: validator,
             io_rt,
             client,
         })
@@ -235,6 +245,11 @@ fn assemble_response(
 
 /// Map [`reqwest::Error`] to [`HttpErrorCode`].
 fn map_reqwest_err(e: reqwest::Error) -> HttpErrorCode {
+    // known "internal" case
+    if let Some(e) = extract_error_type::<ResolvedPortNotZero>(&e) {
+        return HttpErrorCode::InternalError(Some(e.to_string()));
+    }
+
     // try to find an IO error first, since this is potentially the most low-level information
     if let Some(e) = extract_error_type::<std::io::Error>(&e) {
         match e.kind() {
@@ -243,6 +258,9 @@ fn map_reqwest_err(e: reqwest::Error) -> HttpErrorCode {
             }
             ErrorKind::ConnectionReset => {
                 return HttpErrorCode::ConnectionTerminated;
+            }
+            ErrorKind::NotConnected => {
+                return HttpErrorCode::DestinationUnavailable;
             }
             ErrorKind::TimedOut => {
                 return HttpErrorCode::ConnectionTimeout;
@@ -260,6 +278,13 @@ fn map_reqwest_err(e: reqwest::Error) -> HttpErrorCode {
         } else if e.is_timeout() {
             return HttpErrorCode::ConnectionTimeout;
         }
+    }
+
+    // catch-all for connection-style errors
+    //
+    // This also includes DNS, see https://github.com/seanmonstar/reqwest/issues/1501
+    if e.is_connect() {
+        return HttpErrorCode::DestinationUnavailable;
     }
 
     // cannot really extract anything meaningful, fall back to "internal error" ("internal" as in "in our stack", not

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -7,8 +7,8 @@ pub use crate::{
     component::WasmComponentPrecompiled,
     conversion::limits::TrustedDataLimits,
     http::{
-        AllowCertainHttpRequests, AllowHttpEndpoint, AllowHttpHost, HttpConnectionMode, HttpMethod,
-        HttpPort, HttpRequestRejected, HttpRequestValidator, RejectAllHttpRequests,
+        AllowCertainHttpRequests, AllowHttpEndpoint, AllowHttpHost, HttpConfig, HttpConnectionMode,
+        HttpMethod, HttpPort, HttpRequestRejected, HttpRequestValidator, RejectAllHttpRequests,
     },
     limiter::StaticResourceLimits,
     permissions::WasmPermissions,

--- a/host/src/permissions.rs
+++ b/host/src/permissions.rs
@@ -1,10 +1,8 @@
 //! Permission for guests.
 
-use std::{collections::BTreeMap, num::NonZeroUsize, sync::Arc, time::Duration};
+use std::{collections::BTreeMap, num::NonZeroUsize, time::Duration};
 
-use crate::{
-    HttpRequestValidator, RejectAllHttpRequests, StaticResourceLimits, TrustedDataLimits, VfsLimits,
-};
+use crate::{HttpConfig, StaticResourceLimits, TrustedDataLimits, VfsLimits};
 
 /// Permissions for a WASM component.
 #[derive(Debug)]
@@ -19,8 +17,8 @@ pub struct WasmPermissions {
     /// increasing the timeout.
     pub(crate) inplace_blocking_max_ticks: u32,
 
-    /// Validator for HTTP requests.
-    pub(crate) http: Arc<dyn HttpRequestValidator>,
+    /// HTTP configs.
+    pub(crate) http: HttpConfig,
 
     /// Virtual file system limits.
     pub(crate) vfs: VfsLimits,
@@ -70,7 +68,7 @@ impl Default for WasmPermissions {
             inplace_blocking_max_ticks: inplace_blocking_timeout
                 .div_duration_f32(epoch_tick_time)
                 .floor() as _,
-            http: Arc::new(RejectAllHttpRequests),
+            http: HttpConfig::default(),
             vfs: VfsLimits::default(),
             stderr_bytes: 1024, // 1KB
             resource_limits: StaticResourceLimits::default(),
@@ -111,15 +109,9 @@ impl WasmPermissions {
         }
     }
 
-    /// Set HTTP validator.
-    pub fn with_http<V>(self, http: V) -> Self
-    where
-        V: HttpRequestValidator,
-    {
-        Self {
-            http: Arc::new(http),
-            ..self
-        }
+    /// Set HTTP config.
+    pub fn with_http(self, http: HttpConfig) -> Self {
+        Self { http, ..self }
     }
 
     /// Limit of the stored stderr data.

--- a/host/tests/integration_tests/python/runtime/http/mock_resolver.rs
+++ b/host/tests/integration_tests/python/runtime/http/mock_resolver.rs
@@ -1,0 +1,233 @@
+use std::{
+    collections::HashMap,
+    net::{SocketAddr, ToSocketAddrs},
+    sync::{Arc, Mutex},
+};
+
+use futures_util::FutureExt;
+use reqwest::dns::{Addrs, Name, Resolve, Resolving};
+
+#[derive(Debug)]
+struct Mock {
+    result: Result<Vec<SocketAddr>, MockDnsError>,
+    hits_expected: u64,
+    hits_actual: u64,
+}
+
+#[derive(Debug, Default)]
+struct State {
+    mocks: HashMap<String, Mock>,
+    errors: Vec<String>,
+}
+
+type SharedState = Arc<Mutex<State>>;
+
+#[derive(Debug, Default, Clone)]
+pub(crate) struct MockResolver {
+    state: SharedState,
+}
+
+impl MockResolver {
+    pub(crate) fn mock_ok(&self, name: impl ToString, addrs: Vec<SocketAddr>, hits: u64) {
+        let name = name.to_string();
+
+        let mut state = self.state.lock().unwrap();
+        state.mocks.insert(
+            name,
+            Mock {
+                result: Ok(addrs),
+                hits_expected: hits,
+                hits_actual: 0,
+            },
+        );
+    }
+
+    pub(crate) fn mock_err<E>(&self, name: impl ToString, e: E, hits: u64)
+    where
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        let name = name.to_string();
+
+        let mut state = self.state.lock().unwrap();
+        state.mocks.insert(
+            name,
+            Mock {
+                result: Err(MockDnsError { inner: Arc::new(e) }),
+                hits_expected: hits,
+                hits_actual: 0,
+            },
+        );
+    }
+
+    /// Clear mocks.
+    ///
+    /// # Panic
+    /// Panics if a mock hit count doesn't match or there were any other errors.
+    pub(crate) fn clear_mocks(&self) {
+        let mut state = self.state.lock().unwrap();
+
+        let mut errors = std::mem::take(&mut state.errors);
+
+        // check hit rates
+        for (name, mock) in state.mocks.drain() {
+            if mock.hits_actual != mock.hits_expected {
+                errors.push(format!(
+                    "Should hit {expected} times but got {actual}:\n{name:#?}",
+                    expected = mock.hits_expected,
+                    actual = mock.hits_actual,
+                ));
+            }
+        }
+
+        drop(state);
+
+        if !errors.is_empty() {
+            let msg = format!("Resolver Errors:\n\n{}", errors.join("\n\n"));
+
+            // don't double-panic
+            if std::thread::panicking() {
+                eprintln!("{msg}");
+            } else {
+                panic!("{msg}");
+            }
+        }
+    }
+}
+
+impl Drop for MockResolver {
+    fn drop(&mut self) {
+        self.clear_mocks();
+    }
+}
+
+impl Resolve for MockResolver {
+    fn resolve(&self, name: Name) -> Resolving {
+        let mut state = self.state.lock().unwrap();
+        let res = match state.mocks.get_mut(name.as_str()) {
+            Some(mock) => {
+                mock.hits_actual += 1;
+                mock.result.clone()
+            }
+            None => {
+                let msg = format!("no DNS mock for `{}`", name.as_str());
+                state.errors.push(msg.clone());
+                Err(MockDnsError {
+                    inner: Arc::new(std::io::Error::other(msg)),
+                })
+            }
+        };
+
+        async move {
+            match res {
+                Ok(addrs) => Ok(Box::new(addrs.into_iter()) as Addrs),
+                Err(e) => Err(Box::new(e) as Box<dyn std::error::Error + Send + Sync>),
+            }
+        }
+        .boxed()
+    }
+}
+
+#[derive(Debug, Clone)]
+struct MockDnsError {
+    inner: Arc<dyn std::error::Error + Send + Sync>,
+}
+
+impl std::fmt::Display for MockDnsError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "DNS: {}", self.inner)
+    }
+}
+
+impl std::error::Error for MockDnsError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self.inner.as_ref())
+    }
+}
+
+/// There is no stable interface to construct a "DNS not found" error, so we need to create one.
+pub(crate) fn dns_not_found_err() -> std::io::Error {
+    // `.invalid` is reserved and will never resolve
+    ("x.invalid", 0).to_socket_addrs().unwrap_err()
+}
+
+mod tests {
+    use crate::integration_tests::python::runtime::http::test_utils::should_panic;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_happy_path() {
+        let resolver = MockResolver::default();
+        let addrs = vec!["127.0.0.1:0".parse().unwrap()];
+        resolver.mock_ok("foo.test", addrs.clone(), 1);
+
+        let actual = resolver
+            .resolve("foo.test".parse().unwrap())
+            .await
+            .unwrap()
+            .collect::<Vec<_>>();
+        assert_eq!(actual, addrs);
+    }
+
+    #[tokio::test]
+    async fn test_not_hit() {
+        let resolver = MockResolver::default();
+        resolver.mock_ok("foo.test", vec![], 1);
+
+        insta::assert_snapshot!(
+            should_panic(move || {
+                drop(resolver);
+            }),
+            @r#"
+        Resolver Errors:
+
+        Should hit 1 times but got 0:
+        "foo.test"
+        "#,
+        );
+    }
+
+    #[tokio::test]
+    async fn test_no_mock() {
+        let resolver = MockResolver::default();
+
+        // NOTE: cannot use `unwrap_err` here because the Ok(...) side doesn't implement Debug
+        let err = match resolver.resolve("foo.test".parse().unwrap()).await {
+            Ok(_) => {
+                panic!("should not succeed")
+            }
+            Err(e) => e,
+        };
+        insta::assert_snapshot!(
+            err.to_string(),
+            @"DNS: no DNS mock for `foo.test`"
+        );
+
+        insta::assert_snapshot!(
+            should_panic(move || {
+                drop(resolver);
+            }),
+            @r"
+        Resolver Errors:
+
+        no DNS mock for `foo.test`
+        ",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_no_double_panic() {
+        let resolver = MockResolver::default();
+        resolver.mock_ok("foo.test", vec![], 1);
+
+        insta::assert_snapshot!(
+            should_panic(move || {
+                if true {
+                    panic!("foo");
+                }
+                drop(resolver);
+            }),
+            @"foo",
+        );
+    }
+}

--- a/host/tests/integration_tests/python/runtime/http/mock_server.rs
+++ b/host/tests/integration_tests/python/runtime/http/mock_server.rs
@@ -203,6 +203,7 @@ pub(crate) enum Failure {
 pub(crate) struct MockServerOptions {
     pub(crate) ip_version: IpVersion,
     pub(crate) failure: Option<Failure>,
+    pub(crate) hostname: Option<String>,
 }
 
 type SharedState = Arc<Mutex<State>>;
@@ -212,6 +213,7 @@ pub(crate) struct MockServer {
     _task: JoinSet<()>,
     state: SharedState,
     addr: SocketAddr,
+    hostname: String,
 }
 
 impl MockServer {
@@ -223,6 +225,7 @@ impl MockServer {
         let MockServerOptions {
             ip_version,
             failure,
+            hostname,
         } = options;
         let tcp_listener = TcpListener::bind(match ip_version {
             IpVersion::V4 => LISTEN_ADDR_IPV4,
@@ -232,11 +235,14 @@ impl MockServer {
         .expect("bind");
         let addr = tcp_listener.local_addr().unwrap();
 
+        let hostname = hostname.unwrap_or_else(|| addr.ip().to_string());
+
         let state = SharedState::default();
 
         let mut task = JoinSet::new();
         if failure != Some(Failure::RejectConnections) {
             let state_captured = Arc::clone(&state);
+            let hostname_captured = hostname.clone();
             task.spawn(async move {
                 let mut connections = JoinSet::new();
 
@@ -254,6 +260,7 @@ impl MockServer {
                     }
 
                     let state = Arc::clone(&state_captured);
+                    let hostname = hostname_captured.clone();
                     let serve_connection = async move {
                         let result =
                             hyper_util::server::conn::auto::Builder::new(TokioExecutor::new())
@@ -261,6 +268,7 @@ impl MockServer {
                                     TokioIo::new(stream),
                                     service_fn(move |req: http::Request<Incoming>| {
                                         let state = Arc::clone(&state);
+                                        let hostname = hostname.clone();
 
                                         async move {
                                             // hydrate entire body so we can process it easier
@@ -270,7 +278,7 @@ impl MockServer {
 
                                             let mut state = state.lock().unwrap();
 
-                                            if has_forbidden_headers(&req, addr) {
+                                            if has_forbidden_headers(&req, &hostname, addr.port()) {
                                                 return Ok(state.fail(format!(
                                                     "Forbidden headers:\n{req:#?}"
                                                 )));
@@ -327,15 +335,26 @@ impl MockServer {
             _task: task,
             state,
             addr,
+            hostname,
         }
     }
 
-    pub(crate) fn address(&self) -> SocketAddr {
-        self.addr
+    pub(crate) fn hostname(&self) -> String {
+        self.hostname.clone()
+    }
+
+    pub(crate) fn port(&self) -> u16 {
+        self.addr.port()
     }
 
     pub(crate) fn uri(&self) -> String {
-        format!("http://{}", self.addr)
+        let mut hostname = self.hostname().to_owned();
+        // enclose IPv6 addresses
+        if hostname.contains(":") {
+            hostname = format!("[{hostname}]");
+        }
+
+        format!("http://{hostname}:{port}", port = self.port())
     }
 
     pub(crate) fn mock(&self, mock: ServerMock) {
@@ -384,11 +403,11 @@ impl Drop for MockServer {
     }
 }
 
-fn has_forbidden_headers(request: &Request, addr: SocketAddr) -> bool {
+fn has_forbidden_headers(request: &Request, hostname: &str, port: u16) -> bool {
     // "host" is part of the forbidden headers that the client is not supposed to use, but it is set by our own
     // host HTTP lib
     if let Some(host_val) = request.headers().get(http::header::HOST)
-        && host_val.to_str().expect("always a string") != addr.to_string()
+        && host_val.to_str().expect("always a string") != format!("{hostname}:{port}")
     {
         return true;
     }
@@ -405,6 +424,8 @@ mod tests {
 
     use http::HeaderValue;
     use regex::Regex;
+
+    use crate::integration_tests::python::runtime::http::test_utils::should_panic;
 
     use super::*;
 
@@ -620,6 +641,7 @@ mod tests {
         let server = MockServer::start().await;
         server.mock(ServerMock::default());
 
+        set_crypto_provider();
         let resp = reqwest::Client::new()
             .get(server.uri())
             .send()
@@ -682,6 +704,7 @@ mod tests {
     async fn test_forbidden_headers() {
         let server = MockServer::start().await;
 
+        set_crypto_provider();
         let resp = reqwest::Client::new()
             .get(server.uri())
             .header(http::header::CONNECTION, "upgrade")
@@ -735,6 +758,7 @@ mod tests {
     async fn test_wrong_hostname() {
         let server = MockServer::start().await;
 
+        set_crypto_provider();
         let resp = reqwest::Client::new()
             .get(server.uri())
             .header(http::header::HOST, "foo.bar")
@@ -786,6 +810,7 @@ mod tests {
     async fn test_not_mocked() {
         let server = MockServer::start().await;
 
+        set_crypto_provider();
         let resp = reqwest::Client::new()
             .get(server.uri())
             .send()
@@ -832,24 +857,6 @@ mod tests {
         );
     }
 
-    fn should_panic<F>(f: F) -> String
-    where
-        F: FnOnce(),
-    {
-        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)) {
-            Ok(()) => panic!("did not panic"),
-            Err(msg) => {
-                if let Some(msg) = msg.downcast_ref::<&str>() {
-                    msg.to_string()
-                } else if let Some(msg) = msg.downcast_ref::<String>() {
-                    msg.clone()
-                } else {
-                    panic!("cannot extract message")
-                }
-            }
-        }
-    }
-
     /// Normalize addresses since they are not deterministic.
     fn normalize_addr(e: impl ToString) -> String {
         let e = e.to_string();
@@ -858,5 +865,12 @@ mod tests {
             LazyLock::new(|| Regex::new(r#"[0-9]+(\.[0-9]+){3}:[0-9]+"#).unwrap());
 
         REGEX.replace_all(&e, r#"<ADDR>"#).to_string()
+    }
+
+    // https://github.com/seanmonstar/reqwest/issues/2924
+    fn set_crypto_provider() {
+        if rustls::crypto::CryptoProvider::get_default().is_none() {
+            let _ = rustls::crypto::ring::default_provider().install_default();
+        }
     }
 }

--- a/host/tests/integration_tests/python/runtime/http/mod.rs
+++ b/host/tests/integration_tests/python/runtime/http/mod.rs
@@ -16,7 +16,7 @@ use datafusion_expr::{
     ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, async_udf::AsyncScalarUDFImpl,
 };
 use datafusion_udf_wasm_host::{
-    AllowCertainHttpRequests, HttpConnectionMode, HttpPort, HttpRequestValidator, WasmPermissions,
+    AllowCertainHttpRequests, HttpConfig, HttpConnectionMode, HttpPort, WasmPermissions,
     WasmScalarUdf,
 };
 use http::{
@@ -30,16 +30,21 @@ use wasmtime_wasi_http::DEFAULT_FORBIDDEN_HEADERS;
 
 use crate::integration_tests::{
     python::{
-        runtime::http::mock_server::{
-            Matcher, MockServer, MockServerOptions, Request, ResponseGenFn, ServerMock,
-            SimpleResponseGen,
+        runtime::http::{
+            mock_resolver::{MockResolver, dns_not_found_err},
+            mock_server::{
+                Matcher, MockServer, MockServerOptions, Request, ResponseGenFn, ServerMock,
+                SimpleResponseGen,
+            },
         },
         test_utils::{python_component, python_scalar_udf},
     },
     test_utils::ColumnarValueExt,
 };
 
+mod mock_resolver;
 mod mock_server;
+mod test_utils;
 
 #[tokio::test]
 async fn test_requests_simple() {
@@ -59,13 +64,14 @@ def perform_request(url: str) -> str:
         ..Default::default()
     });
 
-    let mut permissions = AllowCertainHttpRequests::new();
-    let endpoint = permissions
-        .allow_host(server.address().ip().to_string())
-        .allow_port(HttpPort::new(server.address().port()).unwrap());
+    let mut validator = AllowCertainHttpRequests::new();
+    let endpoint = validator
+        .allow_host(server.hostname())
+        .allow_port(HttpPort::new(server.port()).unwrap());
     endpoint.allow_mode(HttpConnectionMode::PlainText);
     endpoint.allow_method(http::Method::GET);
-    let udf = python_udf_with_permissions(CODE, permissions).await;
+    let udf =
+        python_udf_with_http_config(CODE, HttpConfig::default().with_validator(validator)).await;
 
     let array = udf
         .invoke_async_with_args(ScalarFunctionArgs {
@@ -116,7 +122,7 @@ def perform_request(url: str) -> str:
     // the port number is part of the error message and not deterministic, so we replace it with a placeholder
     let err = err
         .to_string()
-        .replace(&format!("port={}", server.address().port()), "port=???");
+        .replace(&format!("port={}", server.port()), "port=???");
 
     insta::assert_snapshot!(
         normalize_exception_location(err),
@@ -249,10 +255,8 @@ def test_urllib3(method: str, url: str, headers: str | None, body: str | None) -
             url=url,
             headers=_headers_str_to_dict(headers),
             body=body,
+            retries=False,
         )
-    except urllib3.exceptions.MaxRetryError as e:
-        e = e.reason
-        return f"ERR: {e}"
     except Exception as e:
         return f"ERR: {e}"
 
@@ -293,6 +297,14 @@ def test_urllib3(method: str, url: str, headers: str | None, body: str | None) -
             "no_answer",
             MockServer::with_options(MockServerOptions {
                 failure: Some(mock_server::Failure::CloseWithoutAnswer),
+                ..Default::default()
+            })
+            .await,
+        ),
+        (
+            "via_dns",
+            MockServer::with_options(MockServerOptions {
+                hostname: Some("works.test".to_owned()),
                 ..Default::default()
             })
             .await,
@@ -374,7 +386,8 @@ def test_urllib3(method: str, url: str, headers: str | None, body: str | None) -
             ..Default::default()
         },
         TestCase {
-            base: Some("http://test.com"),
+            hostname: Some("denied.test"),
+            allow: false,
             resp: Err("('Connection aborted.', WasiErrorCode('Request failed with wasi http error ErrorCode_HttpRequestDenied'))".to_owned()),
             ..Default::default()
         },
@@ -392,9 +405,9 @@ def test_urllib3(method: str, url: str, headers: str | None, body: str | None) -
         TestCase {
             server: "ipv6",
             resp: Err(format!(
-                "Err {{ value: set_authority: Some(\"{ip}:{port}\") }}",
-                ip=servers.get("ipv6").unwrap().address().ip(),
-                port=servers.get("ipv6").unwrap().address().port(),
+                "Err {{ value: set_authority: Some(\"{hostname}:{port}\") }}",
+                hostname=servers.get("ipv6").unwrap().hostname(),
+                port=servers.get("ipv6").unwrap().port(),
             )),
             ..Default::default()
         },
@@ -406,6 +419,29 @@ def test_urllib3(method: str, url: str, headers: str | None, body: str | None) -
         TestCase {
             server: "no_answer",
             resp: Err("('Connection aborted.', WasiErrorCode('Request failed with wasi http error ErrorCode_HttpResponseIncomplete'))".to_owned()),
+            ..Default::default()
+        },
+        TestCase {
+            server: "via_dns",
+            resp: Ok(TestResponse {
+                body: Some("hello DNS"),
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+        TestCase {
+            hostname: Some("empty.test"),
+            resp: Err("('Connection aborted.', WasiErrorCode('Request failed with wasi http error ErrorCode_DestinationUnavailable'))".to_owned()),
+            ..Default::default()
+        },
+        TestCase {
+            hostname: Some("invalid.test"),
+            resp: Err("('Connection aborted.', WasiErrorCode('Request failed with wasi http error ErrorCode_DestinationUnavailable'))".to_owned()),
+            ..Default::default()
+        },
+        TestCase {
+            hostname: Some("portnotzero.test"),
+            resp: Err("('Connection aborted.', WasiErrorCode('Request failed with wasi http error ErrorCode_InternalError { value: Some(\"resolved port for `portnotzero.test` is not zero: 1234\") }'))".to_owned()),
             ..Default::default()
         },
     ];
@@ -421,7 +457,7 @@ def test_urllib3(method: str, url: str, headers: str | None, body: str | None) -
                 ..Default::default()
             }),
     );
-    let mut permissions = AllowCertainHttpRequests::default();
+    let mut validator = AllowCertainHttpRequests::default();
 
     let mut builder_method = StringBuilder::new();
     let mut builder_url = StringBuilder::new();
@@ -432,24 +468,26 @@ def test_urllib3(method: str, url: str, headers: str | None, body: str | None) -
     for case in &cases {
         let TestCase {
             server,
-            base,
+            hostname,
             method,
             path,
             requ_headers,
             requ_body,
+            allow: _,
             resp,
         } = case;
 
-        case.allow(&servers, &mut permissions);
+        case.allow(&servers, &mut validator);
 
         let server = servers.get(server).unwrap();
 
+        let base = match hostname {
+            Some(hostname) => format!("http://{hostname}:{port}", port = server.port()),
+            None => server.uri(),
+        };
+
         builder_method.append_value(method);
-        builder_url.append_value(format!(
-            "{}{}",
-            base.map(|b| b.to_owned()).unwrap_or_else(|| server.uri()),
-            path
-        ));
+        builder_url.append_value(format!("{base}{path}"));
         builder_headers.append_option(headers_to_string(requ_headers));
         builder_body.append_option(requ_body.map(|s| s.to_owned()));
 
@@ -491,7 +529,17 @@ def test_urllib3(method: str, url: str, headers: str | None, body: str | None) -
     };
     let array_result = builder_result.finish();
 
-    let udfs = python_udfs_with_permissions(CODE, permissions).await;
+    let resolver = MockResolver::default();
+
+    let udfs = python_udfs_with_http_config(
+        CODE,
+        HttpConfig::default()
+            // avoid connection caching
+            .with_pool_max_idle_per_host(0)
+            .with_resolver(resolver.clone())
+            .with_validator(validator),
+    )
+    .await;
     assert_eq!(udfs.len(), NUMBER_OF_IMPLEMENTATIONS);
 
     for udf in udfs {
@@ -501,6 +549,14 @@ def test_urllib3(method: str, url: str, headers: str | None, body: str | None) -
         for case in &cases {
             case.mock(&servers);
         }
+        resolver.mock_ok("works.test", vec!["127.0.0.1:0".parse().unwrap()], 1);
+        resolver.mock_ok("empty.test", vec![], 1);
+        resolver.mock_err("invalid.test", dns_not_found_err(), 1);
+        resolver.mock_ok(
+            "portnotzero.test",
+            vec!["127.0.0.1:1234".parse().unwrap()],
+            1,
+        );
 
         let actual = udf
             .invoke_async_with_args(args.clone())
@@ -537,6 +593,8 @@ def test_urllib3(method: str, url: str, headers: str | None, body: str | None) -
             println!("clean up server `{name}`...");
             server.clear_mocks();
         }
+        println!("clean up resolver...");
+        resolver.clear_mocks();
     }
 }
 
@@ -559,11 +617,12 @@ impl Default for TestResponse {
 
 struct TestCase {
     server: &'static str,
-    base: Option<&'static str>,
+    hostname: Option<&'static str>,
     method: &'static str,
     path: String,
     requ_headers: Vec<(String, &'static [&'static str])>,
     requ_body: Option<&'static str>,
+    allow: bool,
     resp: Result<TestResponse, String>,
 }
 
@@ -571,11 +630,12 @@ impl Default for TestCase {
     fn default() -> Self {
         Self {
             server: "ipv4",
-            base: None,
+            hostname: None,
             method: "GET",
             path: "/".to_owned(),
             requ_headers: vec![],
             requ_body: None,
+            allow: true,
             resp: Ok(TestResponse::default()),
         }
     }
@@ -588,9 +648,17 @@ impl TestCase {
         permissions: &mut AllowCertainHttpRequests,
     ) {
         let server = servers.get(self.server).unwrap();
+        if !self.allow {
+            return;
+        }
+
         let endpoint = permissions
-            .allow_host(server.address().ip().to_string())
-            .allow_port(HttpPort::new(server.address().port()).unwrap());
+            .allow_host(
+                self.hostname
+                    .map(|s| s.to_owned())
+                    .unwrap_or_else(|| server.hostname()),
+            )
+            .allow_port(HttpPort::new(server.port()).unwrap());
         endpoint.allow_mode(HttpConnectionMode::PlainText);
         endpoint.allow_method(self.method.try_into().unwrap());
     }
@@ -598,15 +666,16 @@ impl TestCase {
     fn mock(&self, servers: &BTreeMap<&'static str, MockServer>) {
         let Self {
             server,
-            base,
+            hostname,
             method,
             path,
             requ_headers,
             requ_body,
+            allow,
             resp,
         } = self;
         let server = servers.get(server).unwrap();
-        if base.is_some() {
+        if !allow || hostname.is_some() {
             return;
         }
 
@@ -675,13 +744,10 @@ fn headers_to_string(headers: &[(String, &[&str])]) -> Option<String> {
     }
 }
 
-async fn python_udfs_with_permissions<V>(code: &'static str, permissions: V) -> Vec<WasmScalarUdf>
-where
-    V: HttpRequestValidator,
-{
+async fn python_udfs_with_http_config(code: &'static str, cfg: HttpConfig) -> Vec<WasmScalarUdf> {
     WasmScalarUdf::new(
         python_component().await,
-        &WasmPermissions::new().with_http(permissions),
+        &WasmPermissions::new().with_http(cfg),
         Handle::current(),
         &(Arc::new(UnboundedMemoryPool::default()) as _),
         code.to_owned(),
@@ -690,11 +756,8 @@ where
     .unwrap()
 }
 
-async fn python_udf_with_permissions<V>(code: &'static str, permissions: V) -> WasmScalarUdf
-where
-    V: HttpRequestValidator,
-{
-    let udfs = python_udfs_with_permissions(code, permissions).await;
+async fn python_udf_with_http_config(code: &'static str, cfg: HttpConfig) -> WasmScalarUdf {
+    let udfs = python_udfs_with_http_config(code, cfg).await;
     assert_eq!(udfs.len(), 1);
     udfs.into_iter().next().unwrap()
 }
@@ -740,16 +803,16 @@ def perform_request(url: str) -> str:
 
     // deliberately use a runtime what we are going to throw away later to prevent tricks like `Handle::current`
     let udf = rt_tmp.block_on(async {
-        let mut permissions = AllowCertainHttpRequests::new();
-        let endpoint = permissions
-            .allow_host(server.address().ip().to_string())
-            .allow_port(HttpPort::new(server.address().port()).unwrap());
+        let mut validator = AllowCertainHttpRequests::new();
+        let endpoint = validator
+            .allow_host(server.hostname())
+            .allow_port(HttpPort::new(server.port()).unwrap());
         endpoint.allow_mode(HttpConnectionMode::PlainText);
         endpoint.allow_method(http::Method::GET);
 
         let udfs = WasmScalarUdf::new(
             python_component().await,
-            &WasmPermissions::new().with_http(permissions),
+            &WasmPermissions::new().with_http(HttpConfig::default().with_validator(validator)),
             rt_io.handle().clone(),
             &(Arc::new(UnboundedMemoryPool::default()) as _),
             CODE.to_owned(),
@@ -838,13 +901,14 @@ async fn assert_large_response_works(code: &'static str) {
         ..Default::default()
     });
 
-    let mut permissions = AllowCertainHttpRequests::new();
-    let endpoint = permissions
-        .allow_host(server.address().ip().to_string())
-        .allow_port(HttpPort::new(server.address().port()).unwrap());
+    let mut validator = AllowCertainHttpRequests::new();
+    let endpoint = validator
+        .allow_host(server.hostname())
+        .allow_port(HttpPort::new(server.port()).unwrap());
     endpoint.allow_mode(HttpConnectionMode::PlainText);
     endpoint.allow_method(http::Method::GET);
-    let udf = python_udf_with_permissions(code, permissions).await;
+    let udf =
+        python_udf_with_http_config(code, HttpConfig::default().with_validator(validator)).await;
 
     let array = udf
         .invoke_async_with_args(ScalarFunctionArgs {
@@ -944,13 +1008,14 @@ def perform_request(url: str) -> str:
         });
     }
 
-    let mut permissions = AllowCertainHttpRequests::new();
-    let endpoint = permissions
-        .allow_host(server.address().ip().to_string())
-        .allow_port(HttpPort::new(server.address().port()).unwrap());
+    let mut validator = AllowCertainHttpRequests::new();
+    let endpoint = validator
+        .allow_host(server.hostname())
+        .allow_port(HttpPort::new(server.port()).unwrap());
     endpoint.allow_mode(HttpConnectionMode::PlainText);
     endpoint.allow_method(http::Method::GET);
-    let udf = python_udf_with_permissions(CODE, permissions).await;
+    let udf =
+        python_udf_with_http_config(CODE, HttpConfig::default().with_validator(validator)).await;
 
     let array = udf
         .invoke_async_with_args(ScalarFunctionArgs {

--- a/host/tests/integration_tests/python/runtime/http/test_utils.rs
+++ b/host/tests/integration_tests/python/runtime/http/test_utils.rs
@@ -1,0 +1,18 @@
+/// Assert that the given function panics and return the panic message.
+pub(crate) fn should_panic<F>(f: F) -> String
+where
+    F: FnOnce(),
+{
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)) {
+        Ok(()) => panic!("did not panic"),
+        Err(msg) => {
+            if let Some(msg) = msg.downcast_ref::<&str>() {
+                msg.to_string()
+            } else if let Some(msg) = msg.downcast_ref::<String>() {
+                msg.clone()
+            } else {
+                panic!("cannot extract message")
+            }
+        }
+    }
+}


### PR DESCRIPTION
Allows tests & API users (NOT guests!) to set their own DNS resolver. Extends test suite so we actually test named hosts (not just direct IP connections) too.

This will help with #448 and #434.
