### PR TITLE
chore: Rust 1.95

### DIFF
--- a/host/tests/integration_tests/evil/runtime.rs
+++ b/host/tests/integration_tests/evil/runtime.rs
@@ -216,7 +216,7 @@ async fn test_thread() {
     stderr:
 
     thread '<unnamed>' (<THREAD>) panicked at <FILE>:<LINE>:<ROW>:
-    failed to spawn thread: Error { kind: Unsupported, message: "operation not supported on this platform" }
+    failed to spawn thread: Os { code: 58, kind: Unsupported, message: "Not supported" }
     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 
     caused by

--- a/rust-toolchain.nightly.toml
+++ b/rust-toolchain.nightly.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2026-03-31"
+channel = "nightly-2026-04-14"
 components = ["rust-src"]
 targets = ["wasm32-wasip2"]
 profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.94.0"
+channel = "1.95.0"
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-wasip2"]


### PR DESCRIPTION
The nightly compiler was bumped to the build date of the respective stable version.
