### PR TITLE
ci: cap GITHUB_TOKEN to contents: read

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ on:
     tags:
       - v*
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` at workflow level. No GitHub API writes from the workflow.

Post-CVE-2025-30066 (`tj-actions/changed-files`) hardening pattern. YAML validated locally.